### PR TITLE
ci: add Python 3.13 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - name: Checkout repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Extended CI test matrix to include Python 3.13 (closes #29).
 - Standardized GitHub contribution infrastructure:
   - Pull Request template with integrated checklists.
   - Structured YAML Issue templates for Bug Reports and Feature Requests.


### PR DESCRIPTION
## What

Add Python 3.13 to the GitHub Actions CI test matrix.

## Why

Python 3.13 is the latest stable release and is not currently covered by CI, meaning compatibility regressions could go unnoticed. Fixes #29.

## How

Append `"3.13"` to the `python-version` matrix in `.github/workflows/ci.yml`. The existing `fail-fast: false` strategy means a failure on 3.13 won't block the other versions while any compatibility issues are investigated.

Also updated `CHANGELOG.md` under `[Unreleased] → Added` to record the expanded coverage.

## Scope

- **Included:** Python 3.13 added to the `test` job matrix; CHANGELOG entry added.
- **NOT included:** Any code changes to address 3.13 compatibility issues (none found; if CI reveals any, they would be addressed in a follow-up PR).

## Verification

- [x] CI runs automatically on this PR — all five Python versions (3.9–3.13) should execute the lint, type-check, and test steps.
- [x] No existing tests were modified.

## AI Disclosure

AI tools were used to assist with drafting this PR description. The code change itself (appending `"3.13"` to the YAML array) was manually reviewed and verified against the existing workflow structure.