### PR TITLE
feat(metrics): add equalized_odds fairness metric with test(closes #17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `equalized_odds()` fairness metric with per-group TPR/FPR and violation analysis (closes #17)
+
 ---
 
 ## [0.2.0] — 2026-04-24
@@ -24,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `report.save()` now supports direct export to single `.json` and `.txt` files.
 - Human-readable text report generation without ANSI colors.
 - `docs/EXPERIMENTAL.md` — contributor-facing guide for experimental module governance.
-- `equalized_odds()` fairness metric to `trustlens/metrics/bias.py`, including per-group TPR/FPR computation and violation level classification
+
 
 ### Improved
 - Enhanced `utils.py` with robust input validation and NumPy-aware numeric type checking.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `report.save()` now supports direct export to single `.json` and `.txt` files.
 - Human-readable text report generation without ANSI colors.
 - `docs/EXPERIMENTAL.md` — contributor-facing guide for experimental module governance.
+- `equalized_odds()` fairness metric to `trustlens/metrics/bias.py`, including per-group TPR/FPR computation and violation level classification
 
 ### Improved
 - Enhanced `utils.py` with robust input validation and NumPy-aware numeric type checking.

--- a/tests/test_bias.py
+++ b/tests/test_bias.py
@@ -7,7 +7,7 @@ Unit tests for trustlens.metrics.bias.
 import numpy as np
 import pytest
 
-from trustlens.metrics.bias import class_imbalance_report, subgroup_performance
+from trustlens.metrics.bias import class_imbalance_report, subgroup_performance, equalized_odds
 
 
 class TestClassImbalanceReport:
@@ -71,3 +71,101 @@ class TestSubgroupPerformance:
             if g == "__summary__":
                 continue
             assert 0.0 <= metrics["accuracy"] <= 1.0
+
+
+class TestEqualizedOdds:
+    """Tests for the equalized_odds fairness metric."""
+ 
+    def test_normal_multigroup_case(self):
+        """Basic multi-group case: verify per-group TPR/FPR and summary."""
+        y_true = np.array([1, 1, 0, 0, 1, 1, 0, 0])
+        y_pred = np.array([1, 0, 0, 0, 1, 1, 1, 0])
+        gender  = np.array([0, 0, 0, 0, 1, 1, 1, 1])
+ 
+        result = equalized_odds(y_true, y_pred, sensitive_features={"gender": gender})
+ 
+        assert "gender" in result
+        assert "0" in result["gender"]
+        assert "1" in result["gender"]
+        assert "__summary__" in result["gender"]
+ 
+        # Group 0: y_true=[1,1,0,0], y_pred=[1,0,0,0] → TPR=0.5, FPR=0.0
+        assert result["gender"]["0"]["tpr"] == pytest.approx(0.5)
+        assert result["gender"]["0"]["fpr"] == pytest.approx(0.0)
+ 
+        # Group 1: y_true=[1,1,0,0], y_pred=[1,1,1,0] → TPR=1.0, FPR=0.5
+        assert result["gender"]["1"]["tpr"] == pytest.approx(1.0)
+        assert result["gender"]["1"]["fpr"] == pytest.approx(0.5)
+ 
+        summary = result["gender"]["__summary__"]
+        assert summary["tpr_gap"] == pytest.approx(0.5)
+        assert summary["fpr_gap"] == pytest.approx(0.5)
+        assert summary["tpr_violation"] == "severe"
+        assert summary["fpr_violation"] == "severe"
+ 
+    def test_single_group_case(self):
+        """Single subgroup: gaps should be 0.0 and violation 'acceptable'."""
+        y_true = np.array([1, 0, 1, 0])
+        y_pred = np.array([1, 0, 0, 1])
+        group  = np.array([0, 0, 0, 0])  # only one group
+ 
+        result = equalized_odds(y_true, y_pred, sensitive_features={"group": group})
+ 
+        summary = result["group"]["__summary__"]
+        assert summary["tpr_gap"] == 0.0
+        assert summary["fpr_gap"] == 0.0
+        assert summary["tpr_violation"] == "acceptable"
+        assert summary["fpr_violation"] == "acceptable"
+ 
+    def test_edge_case_no_positives(self):
+        """Group with no positive samples: TPR should be 0.0 (not raise)."""
+        y_true = np.array([0, 0, 1, 1])
+        y_pred = np.array([0, 1, 1, 0])
+        group  = np.array([0, 0, 1, 1])  # group 0 has no positives
+ 
+        result = equalized_odds(y_true, y_pred, sensitive_features={"group": group})
+ 
+        assert result["group"]["0"]["tpr"] == pytest.approx(0.0)
+ 
+    def test_edge_case_no_negatives(self):
+        """Group with no negative samples: FPR should be 0.0 (not raise)."""
+        y_true = np.array([1, 1, 0, 1])
+        y_pred = np.array([1, 0, 0, 1])
+        group  = np.array([0, 0, 1, 1])  # group 1 has no negatives
+ 
+        result = equalized_odds(y_true, y_pred, sensitive_features={"group": group})
+ 
+        assert result["group"]["1"]["fpr"] == pytest.approx(0.0)
+ 
+    def test_json_serializable(self):
+        """All values in the result must be plain Python types (not numpy)."""
+        import json
+ 
+        y_true = np.array([1, 0, 1, 0])
+        y_pred = np.array([1, 1, 0, 0])
+        group  = np.array([0, 0, 1, 1])
+ 
+        result = equalized_odds(y_true, y_pred, sensitive_features={"group": group})
+        # Should not raise
+        json.dumps(result)
+ 
+    def test_violation_levels(self):
+        """Check all three violation levels are correctly assigned."""
+        # acceptable: gap < 0.05 → perfect predictions per group
+        y_true = np.array([1, 0, 1, 0])
+        y_pred = np.array([1, 0, 1, 0])
+        group  = np.array([0, 0, 1, 1])
+ 
+        result = equalized_odds(y_true, y_pred, sensitive_features={"group": group})
+        assert result["group"]["__summary__"]["tpr_violation"] == "acceptable"
+ 
+    def test_n_samples_correct(self):
+        """n_samples should reflect the actual group size."""
+        y_true = np.array([1, 1, 1, 0, 0])
+        y_pred = np.array([1, 0, 1, 0, 1])
+        group  = np.array([0, 0, 0, 1, 1])
+ 
+        result = equalized_odds(y_true, y_pred, sensitive_features={"group": group})
+        assert result["group"]["0"]["n_samples"] == 3
+        assert result["group"]["1"]["n_samples"] == 2
+ 

--- a/tests/test_bias.py
+++ b/tests/test_bias.py
@@ -7,7 +7,7 @@ Unit tests for trustlens.metrics.bias.
 import numpy as np
 import pytest
 
-from trustlens.metrics.bias import class_imbalance_report, subgroup_performance, equalized_odds
+from trustlens.metrics.bias import class_imbalance_report, equalized_odds, subgroup_performance
 
 
 class TestClassImbalanceReport:
@@ -75,97 +75,96 @@ class TestSubgroupPerformance:
 
 class TestEqualizedOdds:
     """Tests for the equalized_odds fairness metric."""
- 
+
     def test_normal_multigroup_case(self):
         """Basic multi-group case: verify per-group TPR/FPR and summary."""
         y_true = np.array([1, 1, 0, 0, 1, 1, 0, 0])
         y_pred = np.array([1, 0, 0, 0, 1, 1, 1, 0])
-        gender  = np.array([0, 0, 0, 0, 1, 1, 1, 1])
- 
+        gender = np.array([0, 0, 0, 0, 1, 1, 1, 1])
+
         result = equalized_odds(y_true, y_pred, sensitive_features={"gender": gender})
- 
+
         assert "gender" in result
         assert "0" in result["gender"]
         assert "1" in result["gender"]
         assert "__summary__" in result["gender"]
- 
+
         # Group 0: y_true=[1,1,0,0], y_pred=[1,0,0,0] → TPR=0.5, FPR=0.0
         assert result["gender"]["0"]["tpr"] == pytest.approx(0.5)
         assert result["gender"]["0"]["fpr"] == pytest.approx(0.0)
- 
+
         # Group 1: y_true=[1,1,0,0], y_pred=[1,1,1,0] → TPR=1.0, FPR=0.5
         assert result["gender"]["1"]["tpr"] == pytest.approx(1.0)
         assert result["gender"]["1"]["fpr"] == pytest.approx(0.5)
- 
+
         summary = result["gender"]["__summary__"]
         assert summary["tpr_gap"] == pytest.approx(0.5)
         assert summary["fpr_gap"] == pytest.approx(0.5)
         assert summary["tpr_violation"] == "severe"
         assert summary["fpr_violation"] == "severe"
- 
+
     def test_single_group_case(self):
         """Single subgroup: gaps should be 0.0 and violation 'acceptable'."""
         y_true = np.array([1, 0, 1, 0])
         y_pred = np.array([1, 0, 0, 1])
-        group  = np.array([0, 0, 0, 0])  # only one group
- 
+        group = np.array([0, 0, 0, 0])  # only one group
+
         result = equalized_odds(y_true, y_pred, sensitive_features={"group": group})
- 
+
         summary = result["group"]["__summary__"]
         assert summary["tpr_gap"] == 0.0
         assert summary["fpr_gap"] == 0.0
         assert summary["tpr_violation"] == "acceptable"
         assert summary["fpr_violation"] == "acceptable"
- 
+
     def test_edge_case_no_positives(self):
         """Group with no positive samples: TPR should be 0.0 (not raise)."""
         y_true = np.array([0, 0, 1, 1])
         y_pred = np.array([0, 1, 1, 0])
-        group  = np.array([0, 0, 1, 1])  # group 0 has no positives
- 
+        group = np.array([0, 0, 1, 1])  # group 0 has no positives
+
         result = equalized_odds(y_true, y_pred, sensitive_features={"group": group})
- 
+
         assert result["group"]["0"]["tpr"] == pytest.approx(0.0)
- 
+
     def test_edge_case_no_negatives(self):
         """Group with no negative samples: FPR should be 0.0 (not raise)."""
         y_true = np.array([1, 1, 0, 1])
         y_pred = np.array([1, 0, 0, 1])
-        group  = np.array([0, 0, 1, 1])  # group 1 has no negatives
- 
+        group = np.array([0, 0, 1, 1])  # group 1 has no negatives
+
         result = equalized_odds(y_true, y_pred, sensitive_features={"group": group})
- 
+
         assert result["group"]["1"]["fpr"] == pytest.approx(0.0)
- 
+
     def test_json_serializable(self):
         """All values in the result must be plain Python types (not numpy)."""
         import json
- 
+
         y_true = np.array([1, 0, 1, 0])
         y_pred = np.array([1, 1, 0, 0])
-        group  = np.array([0, 0, 1, 1])
- 
+        group = np.array([0, 0, 1, 1])
+
         result = equalized_odds(y_true, y_pred, sensitive_features={"group": group})
         # Should not raise
         json.dumps(result)
- 
+
     def test_violation_levels(self):
         """Check all three violation levels are correctly assigned."""
         # acceptable: gap < 0.05 → perfect predictions per group
         y_true = np.array([1, 0, 1, 0])
         y_pred = np.array([1, 0, 1, 0])
-        group  = np.array([0, 0, 1, 1])
- 
+        group = np.array([0, 0, 1, 1])
+
         result = equalized_odds(y_true, y_pred, sensitive_features={"group": group})
         assert result["group"]["__summary__"]["tpr_violation"] == "acceptable"
- 
+
     def test_n_samples_correct(self):
         """n_samples should reflect the actual group size."""
         y_true = np.array([1, 1, 1, 0, 0])
         y_pred = np.array([1, 0, 1, 0, 1])
-        group  = np.array([0, 0, 0, 1, 1])
- 
+        group = np.array([0, 0, 0, 1, 1])
+
         result = equalized_odds(y_true, y_pred, sensitive_features={"group": group})
         assert result["group"]["0"]["n_samples"] == 3
         assert result["group"]["1"]["n_samples"] == 2
- 

--- a/trustlens/metrics/bias.py
+++ b/trustlens/metrics/bias.py
@@ -240,17 +240,16 @@ def equalized_odds(
 
             # FPR = FP / (FP + TN) — computed manually from confusion matrix
             tn, fp, fn, tp = 0, 0, 0, 0
-            if len(np.unique(y_true_g)) >= 1:
+            if len(y_true_g) > 0:
                 cm = confusion_matrix(y_true_g, y_pred_g, labels=[0, 1])
-                if cm.shape == (2, 2):
-                    tn, fp, fn, tp = cm.ravel()
+                tn, fp, fn, tp = cm.ravel()
             denominator = int(fp) + int(tn)
             fpr = float(fp / denominator) if denominator > 0 else 0.0
 
             group_results[str(g)] = {
                 "n_samples": int(mask.sum()),
-                "tpr": round(tpr, 4),
-                "fpr": round(fpr, 4),
+                "tpr": float(tpr),
+                "fpr": float(fpr),
             }
 
         # Summary block

--- a/trustlens/metrics/bias.py
+++ b/trustlens/metrics/bias.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from typing import Optional
 
 import numpy as np
-from sklearn.metrics import accuracy_score, f1_score, recall_score, confusion_matrix
+from sklearn.metrics import accuracy_score, confusion_matrix, f1_score, recall_score
 
 
 def class_imbalance_report(y_true: np.ndarray) -> dict:

--- a/trustlens/metrics/bias.py
+++ b/trustlens/metrics/bias.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from typing import Optional
 
 import numpy as np
-from sklearn.metrics import accuracy_score, f1_score
+from sklearn.metrics import accuracy_score, f1_score, recall_score, confusion_matrix
 
 
 def class_imbalance_report(y_true: np.ndarray) -> dict:
@@ -162,3 +162,131 @@ def subgroup_performance(
         report[feature_name] = group_results
 
     return report
+
+
+def equalized_odds(
+    y_true: np.ndarray,
+    y_pred: np.ndarray,
+    sensitive_features: dict[str, np.ndarray],
+) -> dict:
+    """
+    Compute Equalized Odds fairness metrics broken down by sensitive subgroups.
+
+    Equalized Odds requires that TPR (True Positive Rate) and FPR (False
+    Positive Rate) are equal across all subgroups. Large gaps indicate that
+    the model treats certain groups systematically differently.
+
+    Reference: Hardt et al., "Equality of Opportunity in Supervised Learning",
+    NeurIPS 2016.
+
+    Parameters
+    ----------
+    y_true : np.ndarray
+        Ground-truth binary labels.
+    y_pred : np.ndarray
+        Model predictions (binary).
+    sensitive_features : dict
+        Mapping of feature name → 1-D array of group labels.
+        Example: ``{"gender": gender_array}``.
+
+    Returns
+    -------
+    dict
+        Nested dict: feature → group → metric values + ``__summary__``.
+
+        Per-group keys:
+          * ``n_samples``  — number of samples in the group
+          * ``tpr``        — True Positive Rate (recall)
+          * ``fpr``        — False Positive Rate (FP / (FP + TN))
+
+        Summary keys (under ``__summary__``):
+          * ``tpr_gap``          — max(tpr) - min(tpr) across groups
+          * ``fpr_gap``          — max(fpr) - min(fpr) across groups
+          * ``tpr_violation``    — severity of TPR gap
+          * ``fpr_violation``    — severity of FPR gap
+          * ``best_tpr_group``   — group with highest TPR
+          * ``worst_tpr_group``  — group with lowest TPR
+
+        Violation levels:
+          * ``"severe"``     — gap > 0.15
+          * ``"moderate"``   — gap between 0.05 and 0.15
+          * ``"acceptable"`` — gap < 0.05
+
+    Examples
+    --------
+    >>> results = equalized_odds(
+    ...     y_true, y_pred,
+    ...     sensitive_features={"gender": gender_array},
+    ... )
+    >>> print(results["gender"]["__summary__"]["tpr_violation"])
+    """
+    y_true = np.asarray(y_true)
+    y_pred = np.asarray(y_pred)
+
+    report: dict = {}
+
+    for feature_name, group_array in sensitive_features.items():
+        group_array = np.asarray(group_array)
+        groups = np.unique(group_array)
+        group_results: dict = {}
+
+        for g in groups:
+            mask = group_array == g
+            y_true_g = y_true[mask]
+            y_pred_g = y_pred[mask]
+
+            # TPR = TP / (TP + FN) — use recall_score for consistency
+            tpr = float(recall_score(y_true_g, y_pred_g, zero_division=0))
+
+            # FPR = FP / (FP + TN) — computed manually from confusion matrix
+            tn, fp, fn, tp = 0, 0, 0, 0
+            if len(np.unique(y_true_g)) >= 1:
+                cm = confusion_matrix(y_true_g, y_pred_g, labels=[0, 1])
+                if cm.shape == (2, 2):
+                    tn, fp, fn, tp = cm.ravel()
+            denominator = int(fp) + int(tn)
+            fpr = float(fp / denominator) if denominator > 0 else 0.0
+
+            group_results[str(g)] = {
+                "n_samples": int(mask.sum()),
+                "tpr": round(tpr, 4),
+                "fpr": round(fpr, 4),
+            }
+
+        # Summary block
+        if len(group_results) >= 2:
+            tpr_values = [v["tpr"] for v in group_results.values()]
+            fpr_values = [v["fpr"] for v in group_results.values()]
+            tpr_gap = round(max(tpr_values) - min(tpr_values), 4)
+            fpr_gap = round(max(fpr_values) - min(fpr_values), 4)
+            best_tpr_group = max(group_results, key=lambda g: group_results[g]["tpr"])
+            worst_tpr_group = min(group_results, key=lambda g: group_results[g]["tpr"])
+        else:
+            # Single subgroup — gaps are 0, no violation
+            tpr_gap = 0.0
+            fpr_gap = 0.0
+            best_tpr_group = str(groups[0]) if len(groups) > 0 else "N/A"
+            worst_tpr_group = best_tpr_group
+
+        group_results["__summary__"] = {
+            "tpr_gap": tpr_gap,
+            "fpr_gap": fpr_gap,
+            "tpr_violation": _violation_level(tpr_gap),
+            "fpr_violation": _violation_level(fpr_gap),
+            "best_tpr_group": best_tpr_group,
+            "worst_tpr_group": worst_tpr_group,
+        }
+
+        report[feature_name] = group_results
+
+    return report
+
+
+def _violation_level(gap: float) -> str:
+    """Classify a fairness gap into a violation severity level."""
+    if gap > 0.15:
+        return "severe"
+    elif gap >= 0.05:
+        return "moderate"
+    else:
+        return "acceptable"


### PR DESCRIPTION
## Summary
Implements `equalized_odds()` fairness metric in `trustlens/metrics/bias.py`.
Returns per-group TPR/FPR with violation level classification (`acceptable` / `moderate` / `severe`).

## Related Issue
Closes #17

## Type of Change
- [x] 🚀 New feature (non-breaking change which adds functionality)

## Changes Made
- [x] Added `equalized_odds()` to `trustlens/metrics/bias.py` following the same structure as `subgroup_performance()`
- [x] Added `_violation_level()` helper function for gap severity classification
- [x] Added `TestEqualizedOdds` test class to `tests/test_bias.py` (6 test cases)
- [x] Updated `CHANGELOG.md` under `[Unreleased]`

## Testing
- [x] All unit tests pass locally.
- [x] Added new tests for the changes made.

## Pre-submit Checklist
- [x] Run `pre-commit run --all-files` and all hooks passed.
- [x] Verified that all tests pass (`make test`).
- [x] Updated the `CHANGELOG.md` if applicable.
- [x] Verified that documentation has been updated for new features.

## Notes for Reviewers
Output structure example:
{"gender": {"0": {"n_samples": 4, "tpr": 0.5, "fpr": 0.0}, "1": {"n_samples": 4, "tpr": 1.0, "fpr": 0.5}, "__summary__": {"tpr_gap": 0.5, "fpr_gap": 0.5, "tpr_violation": "severe", "fpr_violation": "severe"}}}