### PR TITLE
docs: restructure handbook and strengthen README landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,124 +1,141 @@
 <div align="center">
   <img src="assets/banner1.png" alt="TrustLens Banner" width="100%" />
 
-<br/>
+### Your model has 92% accuracy. That may still be unsafe.
 
-### Your model has 92% accuracy. **That's not enough.**
-
-**The open-source Python library that transforms model metrics into actionable deployment decisions.**
-TrustLens bridges the gap between model evaluation and deployment decision-making by evaluating reliability, robustness, and fairness in one function call.
-
-
-
-<br/>
+TrustLens is an open-source Python library for evaluating model reliability beyond accuracy and producing deployment-ready decisions.
 
 [![PyPI version](https://badge.fury.io/py/trustlens.svg)](https://pypi.org/project/trustlens/)
 [![CI](https://github.com/Khanz9664/TrustLens/actions/workflows/ci.yml/badge.svg)](https://github.com/Khanz9664/TrustLens/actions)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![Stars](https://img.shields.io/github/stars/Khanz9664/TrustLens?style=social)](https://github.com/Khanz9664/TrustLens/stargazers)
 [![PyPI Downloads](https://img.shields.io/pypi/dm/trustlens)](https://pypi.org/project/trustlens)
 [![Code of Conduct](https://img.shields.io/badge/code%20of%20conduct-Contributor%20Covenant-blue.svg)](CODE_OF_CONDUCT.md)
 
-<br/>
-
-⭐ **Star the repo to support the project!**
-
-🛠 **Actively looking for contributors - beginner-friendly issues available**
-
-<br/>
-
-[**Get Started**](#quickstart) · [**Docs**](docs/index.md) · [**Live Demo**](examples/trustlens_demo.ipynb) · [**PyPI**](https://pypi.org/project/trustlens) · [**Discussions**](https://github.com/Khanz9664/TrustLens/discussions)
-
+[Get Started](#quickstart) · [Documentation](docs/index.md) · [Live Demo](examples/trustlens_demo.ipynb) · [PyPI](https://pypi.org/project/trustlens) · [Discussions](https://github.com/Khanz9664/TrustLens/discussions)
 </div>
 
 ---
 
-## What TrustLens Does
-TrustLens is a **decision-support system** designed to answer the hardest question in ML: *"Should I deploy this model?"*
+## Why TrustLens
 
-Unlike standard metric libraries, TrustLens provides a cohesive diagnostic layer that evaluates:
-- **Reliability (Calibration)**: Are the model's probabilities trust-worthy?
-- **Robustness (Failure)**: Where and why does the model fail?
-- **Fairness (Bias)**: Are errors disproportionately affecting certain groups?
+Most model evaluations stop at accuracy, AUC, or F1. Deployment decisions require more:
 
-The results are synthesized into a **Trust Score** and an actionable **deployment verdict**, enabling practitioners to move from simple metric evaluation to informed deployment decisions.
+- Can we trust model probabilities?
+- Are failures concentrated in high-confidence regions?
+- Is performance uneven across sensitive groups?
+- Are we shipping a model with hidden reliability risk?
 
+TrustLens answers these questions in one pipeline and produces:
 
-
----
-
-## One-Line Magic
-**Full reliability analysis in one line.**
-
-```python
-from trustlens import quick_analyze
-quick_analyze(dataset="breast_cancer").show()
-```
-
-> **Looking for the full documentation?**
-> Head over to the [**TrustLens Documentation Hub**](docs/index.md) for deep dives into features, use cases, and architecture.
+- module-level diagnostics (calibration, failure, bias, representation)
+- a composite Trust Score (0-100)
+- penalty and blocker reasoning
+- a deployment verdict suitable for review and CI gating
 
 ---
 
 ## Quickstart
 
-### 1. Install
+### Install
+
 ```bash
 pip install trustlens
 ```
 
-### 2. Analyze Your Model
+### Analyze a Model
+
 ```python
 from trustlens import analyze
 
-report = analyze(model, X_test, y_test, y_prob)
+report = analyze(model, X_test, y_test, y_prob=model.predict_proba(X_test))
 report.show()
 ```
 
-**Real Output Snippet:**
+### Example Output
+
 ```text
 TRUST SCORE: 88/100 [B]
-Assessment : High Trust - ready for controlled deployment
+Assessment : Good Trust - minor issues to address
 
-Score Explanation:
-  - Dominant Issue  : Calibration (-12.0)
-  - Secondary Issue : Fairness (-0.0)
+Score Summary:
+  Base Score        : 92
+  Penalties Applied : -4.0 [Calibration (-4.0)]
+  Final Score       : 88
 ```
 
-### 3. Compare Models
+### Compare Candidates
+
 ```python
 from trustlens import compare
 
-# Compare multiple candidates and get a recommendation
-compare([report_rf, report_logistic])
+compare([report_model_a, report_model_b, report_model_c])
 ```
 
-### 4. Save & Export
+### Export Artifacts
 
 ```python
-report.save("report.json") # For CI/CD
-report.save("report.txt")  # For humans
+report.save("report.json")   # machine-readable
+report.save("report.txt")    # human-readable
+report.save("trust_report")  # full bundle with plots + metadata
 ```
 
 ---
 
-## Understanding the Output
-TrustLens provides a multi-layered diagnostic report:
-- **Trust Score**: A weighted combination (configurable, default ~40/40/20) of Calibration, Failure, and Bias. Includes **automatic penalties** for critical risks.
-- **Failure Score**: Reflects **confidence-weighted errors**, not raw error rate. It identifies if errors are concentrated in high-certainty zones.
-- **Calibration**: Measures probability reliability via Expected Calibration Error (ECE).
-- **Fairness Margin**: Quantifies distance from the acceptable disparity threshold (0.10).
-- **Pattern Detection**: Alerts you to behaviors like **Calibration Drift** (unreliable probabilities) or **Confidently Wrong** (high-certainty mistakes).
+## One-Line Demo
 
-
+```python
+from trustlens import quick_analyze
+quick_analyze(dataset="breast_cancer")
+```
 
 ---
 
-## Documentation
+## Core Capabilities
 
-Detailed guides and architecture references are available in our [structured documentation](docs/index.md)
+- **Calibration diagnostics**: Brier score, ECE, reliability curve data
+- **Failure diagnostics**: misclassification analysis and confidence-gap risk signals
+- **Bias and fairness diagnostics**: class imbalance, subgroup performance, equalized-odds checks
+- **Representation diagnostics**: embedding separability when embeddings are provided
+- **Decision engine**: weighted trust score with penalties and deployment blockers
+- **Reporting**: console summary, plots, JSON/TXT export, model comparison utility
 
-<!-- Maintainers: Consider updating GitHub repository description to: "Debug your ML models beyond accuracy | Structured docs in /docs" -->
+---
+
+## How the Decision Works
+
+TrustLens computes sub-scores across available dimensions, applies weights, then applies penalties and blockers for high-risk conditions.
+
+Use this ordering when reading output:
+
+1. Check `is_blocked` and verdict.
+2. Check final Trust Score and grade.
+3. Check penalties to identify dominant risk dimensions.
+4. Inspect module-level diagnostics for remediation.
+
+Deep dive: [Trust Score Explained](docs/trust_score_explained.md)
+
+---
+
+## Documentation Map
+
+- Start: [Getting Started](docs/getting_started.md)
+- Concepts: [Features and Modules](docs/features.md)
+- Workflow guides: [Guides](docs/guides/model_comparison_workflow.md)
+- Limits and caveats: [Known Limitations](docs/known_limitations.md)
+- API docs: [API Reference](docs/api_reference.md)
+
+---
+
+## Use Cases
+
+TrustLens is designed for practical ML workflows:
+
+- release gating in CI
+- candidate model selection
+- fairness review before deployment
+- post-deployment reliability audits
+
+See [Use Cases](docs/use_cases.md) and [Guides](docs/guides/ci_deployment_gate.md).
 
 ---
 
@@ -128,35 +145,35 @@ Detailed guides and architecture references are available in our [structured doc
   <tr>
     <td align="center">
       <a href="https://github.com/Khanz9664">
-        <img src="https://github.com/Khanz9664.png" width="100px;" style="border-radius:50%;"/>
+        <img src="https://github.com/Khanz9664.png" width="100px;" style="border-radius:50%;" alt="Khanz9664"/>
         <br />
         <sub><b>Khanz9664</b></sub>
       </a>
     </td>
     <td align="center">
       <a href="https://github.com/jayssSmm">
-        <img src="https://github.com/jayssSmm.png" width="100px;" style="border-radius:50%;"/>
+        <img src="https://github.com/jayssSmm.png" width="100px;" style="border-radius:50%;" alt="jayssSmm"/>
         <br />
         <sub><b>jayssSmm</b></sub>
       </a>
     </td>
     <td align="center">
       <a href="https://github.com/WeiGuang-2099">
-        <img src="https://github.com/WeiGuang-2099.png" width="100px;" style="border-radius:50%;"/>
+        <img src="https://github.com/WeiGuang-2099.png" width="100px;" style="border-radius:50%;" alt="WeiGuang-2099"/>
         <br />
         <sub><b>WeiGuang-2099</b></sub>
       </a>
     </td>
     <td align="center">
       <a href="https://github.com/CrepuscularIRIS">
-        <img src="https://github.com/CrepuscularIRIS.png" width="100px;" style="border-radius:50%;"/>
+        <img src="https://github.com/CrepuscularIRIS.png" width="100px;" style="border-radius:50%;" alt="CrepuscularIRIS"/>
         <br />
         <sub><b>CrepuscularIRIS</b></sub>
       </a>
     </td>
     <td align="center">
       <a href="https://github.com/komoike-oss28-ui">
-        <img src="https://github.com/komoike-oss28-ui.png" width="100px;" style="border-radius:50%;"/>
+        <img src="https://github.com/komoike-oss28-ui.png" width="100px;" style="border-radius:50%;" alt="komoike-oss28-ui"/>
         <br />
         <sub><b>komoike-oss28-ui</b></sub>
       </a>
@@ -164,23 +181,23 @@ Detailed guides and architecture references are available in our [structured doc
   </tr>
 </table>
 
-Want to see your name here? Check out `good first issue` 👇
-
-https://github.com/Khanz9664/TrustLens/issues
+Want to see your name here? Start with a [`good first issue`](https://github.com/Khanz9664/TrustLens/issues).
 
 ---
 
 ## Contributing
 
-TrustLens is a production-grade tool, and we welcome developers of all levels. Whether it's fixing a bug, adding a metric, or improving our documentation, your help is appreciated.
+Contributions are welcome across metrics, docs, tests, and integrations.
 
-[**Read the full Contributing Guide →**](CONTRIBUTING.md)
+- Read: [Contributing Guide](CONTRIBUTING.md)
+- Browse issues: [Open Issues](https://github.com/Khanz9664/TrustLens/issues)
+- Join discussions: [Discussions](https://github.com/Khanz9664/TrustLens/discussions)
 
 ---
 
 ## Citation
 
-If you use TrustLens in research or production, please cite it:
+If you use TrustLens in research or production, cite:
 
 ```bibtex
 @software{trustlens2026,
@@ -195,14 +212,5 @@ If you use TrustLens in research or production, please cite it:
 
 ## Author
 
-**Shahid Ul Islam** — ML Engineer & Creator of TrustLens
+Shahid Ul Islam
 [GitHub](https://github.com/Khanz9664) · [Portfolio](https://khanz9664.github.io/portfolio/) · [LinkedIn](https://www.linkedin.com/in/shahid-ul-islam-13650998/)
-
----
-
-<p align="center">
-  <strong>If TrustLens helped you understand your model better, give it a ⭐ — it helps others discover it.</strong><br><br>
-  <a href="https://pypi.org/project/trustlens">PyPI</a> ·
-  <a href="https://github.com/Khanz9664/TrustLens">GitHub</a> ·
-  <a href="https://github.com/Khanz9664/TrustLens/discussions">Discussions</a>
-</p>

--- a/docs/PAGE_TEMPLATE.md
+++ b/docs/PAGE_TEMPLATE.md
@@ -1,0 +1,52 @@
+# Documentation Page Template
+
+Use this template when adding or rewriting documentation pages to keep voice and structure consistent.
+
+## Title
+
+One line describing the practical value of this page.
+
+## Why This Matters
+
+State the real engineering decision this page helps with.
+
+## When to Use
+
+- Scenario 1
+- Scenario 2
+- Scenario 3
+
+## When Not to Use
+
+- Case where this method is not appropriate
+- Known boundary condition
+
+## Inputs and Assumptions
+
+- Required inputs
+- Optional inputs
+- Assumptions and data contracts
+
+## Output and Interpretation
+
+- What this page or method produces
+- How to read the result
+- Common misinterpretations to avoid
+
+## Minimal Example
+
+```python
+# small example here
+```
+
+## Limitations and Caveats
+
+- Statistical caveat
+- Implementation caveat
+- Domain caveat
+
+## Related Pages
+
+- Link to concept page
+- Link to guide
+- Link to API reference

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,16 +1,18 @@
 # System Architecture
 
-TrustLens is a **decision-support framework** designed to transform raw model outputs into actionable deployment decisions. It operates through a decoupled pipeline that separates data orchestration from performance metrics, composite scoring, and narrative interpretation.
+TrustLens is designed as a layered pipeline so diagnostic computation, scoring logic, and report interpretation remain decoupled and maintainable.
 
----
+## Why This Design Matters
 
-## 1. High-Level Perspective
+The architecture aims to solve three practical needs:
 
-TrustLens is structured as a series of specialized layers, each governed by strict data contracts.
+- stable and testable metric computation
+- explicit decision logic with traceable rules
+- clear extension points for contributors
 
-### System-Level Data Flow
+## High-Level Data Flow
 
-This diagram illustrates the end-to-end pipeline from raw model inputs to the final deployment recommendation.
+This diagram shows how inputs move from orchestration to metrics, scoring, and final reporting.
 
 ```mermaid
 graph TD
@@ -34,15 +36,11 @@ graph TD
     Report --> Output[Console / Plots / Saved Files]
 ```
 
-*This diagram shows how raw inputs are transformed into structured metrics, then aggregated into a trust score and final deployment decision.*
+**Implementation note**: `analyze()` resolves probabilities from `predict_proba` when available and only executes optional modules when required metadata is provided.
 
-**Technical Note**: The orchestrator automatically handles `predict_proba` resolution if `y_prob` is not provided, and conditionally executes the **Bias** and **Representation** modules only when the required metadata (`sensitive_features` or `embeddings`) is present.
+## Component Interactions
 
----
-
-## 2. Component Interactions
-
-The system relies on structured data flow between internal components.
+The interaction model is centered around a structured `results` dictionary.
 
 ```mermaid
 graph LR
@@ -54,20 +52,16 @@ graph LR
     Report -- "Insights/Patterns" --> User[User/Developer]
 ```
 
-*This interaction map defines the flow of the internal results dictionary as it is enriched by the metrics and scoring engines before final interpretation.*
-
 ### Data Contracts
 
-1. **API → Metrics**: Passes sanitized numpy arrays (`y_true`, `y_prob`, `y_pred`).
-2. **Metrics → API**: Returns standard dictionaries containing scalars (e.g., `ece`) and plotting vectors (e.g., `reliability_curve_points`).
-3. **API → TrustReport**: Assembles the `results` payload and provides a model reference for metadata extraction.
-4. **TrustReport → TrustScore**: Consumes the `results` dict and evaluates it against predefined threshold constants.
+1. **API to metrics**: normalized arrays (`y_true`, `y_pred`, `y_prob`) and optional metadata.
+2. **Metrics to API**: module-scoped dictionaries with scalar values and plot-friendly arrays.
+3. **API to report**: consolidated `results` plus model and data references.
+4. **Report to scorer**: score computation from `results` including penalties and blockers.
 
----
+## Execution Sequence
 
-## 3. Execution Sequence
-
-The following sequence diagram tracks a single call to `api.analyze()`, highlighting the synchronous handoffs and conditional execution paths.
+This sequence shows one `analyze()` call from input to `TrustReport`.
 
 ```mermaid
 sequenceDiagram
@@ -91,83 +85,59 @@ sequenceDiagram
     Report-->>User: TrustReport Object
 ```
 
-*The sequence trace identifies where high-overhead or data-dependent modules are conditionally activated by the orchestrator.*
-
----
-
-## 4. Layer Responsibilities
+## Layer Responsibilities
 
 ### Orchestration Layer (`api.py`)
-Centrally manages the execution of analysis modules.
 
-* **Validation**: Ensures input consistency (e.g., matching shapes for `X` and `y_true`).
-* **Resolution**: Implements fallback logic for models without `predict_proba`.
-* **Dispatch**: Triggers modular units (`calibration`, `failure`, and conditionally `bias`/`representation`) and manages progress tracking via `tqdm`.
+- validates basic input assumptions
+- resolves probabilities when possible
+- dispatches enabled modules
+- assembles the final `results` payload
 
-### Metrics Engine (`metrics/`)
-Dedicated compute nodes for specialized diagnostics.
+### Metrics Layer (`metrics/`)
 
-* **Calibration**: Computes **Brier Score** and **Expected Calibration Error (ECE)** to measure probability reliability.
-* **Failure Analysis**: Calculates the **Confidence Gap** (difference between correct and incorrect prediction confidence).
-* **Bias Detection**: (*Optional*) Evaluates **Subgroup Performance Gap** and **Equalized Odds** (TPR/FPR parity).
-* **Representation**: (*Optional / Advanced*) Representation analysis using **Silhouette Scores**.
+- computes calibration, failure, bias, and representation diagnostics
+- keeps each metric family independent and testable
+- returns structured outputs for scoring and visualization
 
-### Decision Layer (`trust_score.py`)
-The system's judging engine. It uses a hybrid scoring methodology:
+### Scoring Layer (`trust_score.py`)
 
-1. **Base Score**: A weighted combination (configurable; default ≈ 35 / 30 / 25 / 10).
-2. **Penalty Burden**: Linear deductions for specific failures (e.g., ECE > 0.05).
-3. **Deployment Blockers**: Boolean flags (`is_blocked`) triggered by severe risks. **Critical Note**: Deployment blockers override numeric scores to prevent unsafe model approval regardless of performance in other dimensions.
+- computes sub-scores and weighted composite score
+- redistributes weights for missing dimensions
+- applies penalties and deployment blockers
 
-### Narrative & Interpretation Layer (`report.py`)
-Converts raw numbers into human-readable signals (often referred to as the "Narrative Brain").
+### Reporting Layer (`report.py`)
 
-* **Pattern Detection**: Identifies higher-order behaviors like *"Confidently Wrong"* or *"Calibration Drift"*.
-* **Insight Generation**: Ranks observations by severity (Critical, Warning, Info).
-* **Narrative Serialization**: Generates the final console summaries and the Plotly/Matplotlib dashboards.
+- packages run metadata and module outputs
+- generates textual and visual summaries
+- surfaces patterns and decision-oriented insights
 
-### Comparative Engine (`comparison.py`)
-Provides causal reasoning for multi-model selection. It ranks candidates by score and identifies the "Comparative Advantage".
+### Comparison Layer (`comparison.py`)
 
-* **Example Output**: *"Model A recommended due to lower failure penalty and no active fairness violations."*
+- compares candidate `TrustReport` objects
+- filters blocked candidates
+- provides deployment recommendation rationale
 
----
+## Extensibility Path
 
-## 5. Design Principles
+To add a new metric module:
 
-* **Modular Architecture**: Modules are isolated; failure in one (e.g., bias) does not crash the entire pipeline.
-* **Separation of Concerns**: Each layer operates independently with well-defined data contracts.
-* **Explainability-First**: Every metric is tied to a human-readable "Insight" in the report.
-* **Decision-Support**: TrustLens doesn't just report numbers; it provides a **Verdict** (Deploy vs. Investigate).
-* **Zero-Friction**: Primary entry points (`quick_analyze`) require minimal configuration for demoing.
+1. implement the metric under `trustlens/metrics/`
+2. wire dispatch logic in `analyze()`
+3. ensure return format follows existing `results` conventions
+4. add tests and documentation
+5. optionally integrate into trust score weighting
 
----
+## Architectural Constraints
 
-## 6. Extensibility Architecture
+- optimized for classification evaluation
+- fairness checks are data- and task-dependent
+- representation diagnostics require embeddings
+- some threshold logic is currently heuristic by design
 
-TrustLens is designed to be extended by researchers and engineers.
+## Related Pages
 
-### Example: Adding a New Metric
-1. **Metric Implementation**: Create a function in `trustlens/metrics/new_metric.py`.
-2. **API Integration**: Add the module to the `_ALL_MODULES` registry in `trustlens/api.py`.
-3. **Dispatch Logic**: Add a dispatch block in `api.analyze()` to call your new metric and save results to the dictionary.
-4. **Scoring Integration**: (Optional) Add a weight/sub-score computer in `trust_score.py`.
-
----
-
-## 7. Limitations & Constraints
-
-* **Model Compatibility**: Optimized for Classifiers (binary/multi-class). Regression support is currently experimental.
-* **Data Density**: Calibration metrics (ECE) require a minimum of 30 samples for statistical validity.
-* **Linear Penalties**: Penalty deduction is current linear; non-linear risk modeling is planned for future releases.
-* **Input Requirements**: Interpretability depends on availability of probabilities and optional metadata (e.g., sensitive features).
-
----
-
-## 8. Experimental Ecosystem
-
-Modules marked `[Experimental]` (e.g., **Explainability/Grad-CAM**) are kept isolated from the core production pipeline to:
-
-1. Reduce required dependency bloat (e.g., avoiding mandatory PyTorch).
-2. Allow for research-stage iteration without affecting system stability.
-3. Provide a clear path for promotion based on usage and stability testing (see [`docs/EXPERIMENTAL.md`](EXPERIMENTAL.md)).
+- [Features and Modules](features.md)
+- [Trust Score Explained](trust_score_explained.md)
+- [Known Limitations](known_limitations.md)
+- [Experimental Modules](EXPERIMENTAL.md)

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,57 +1,54 @@
-# Features & Modules
+# Features and Modules
 
-TrustLens provides a suite of specialized modules, each targeting a specific dimension of model reliability.
+TrustLens is organized as focused modules that diagnose model reliability from different angles. Together, they produce one deployment-oriented verdict while preserving detailed diagnostics.
 
----
+## Calibration Module
 
-## 1. Calibration Module
-*Ensure probabilities mean what they say.*
+Calibration checks whether predicted probabilities match real-world outcomes.
 
-Calibration measures the reliability of a model's predicted probabilities. A well-calibrated model that predicts 70% confidence for a set of samples should be correct for approximately 70% of them.
+- **Expected Calibration Error (ECE)**: weighted gap between confidence and observed accuracy across bins.
+- **Brier Score**: mean squared error of probabilistic predictions.
+- **Reliability Curve Data**: confidence versus observed correctness for calibration plots.
 
-- **ECE (Expected Calibration Error)**: Quantifies the average gap between confidence and accuracy across confidence bins.
-- **Brier Score**: Measures the mean squared difference between predicted probabilities and actual outcomes.
-- **Reliability Curves**: Visual diagnostics to identify overconfidence or underconfidence.
+Use calibration results when your downstream decision threshold depends on confidence quality rather than raw class labels.
 
----
+## Failure Analysis Module
 
-## 2. Failure Analysis Module
-*Identify the "Confidently Wrong" patterns.*
+Failure analysis focuses on risk concentration, not only total error rate.
 
-High-accuracy models often hide dangerous failure modes. This module drills down into the errors.
+- **Misclassification Summary**: class-wise error rates and high-confidence mistakes.
+- **Confidence Gap**: difference between confidence on correct predictions and confidence on incorrect predictions.
+- **Failure Pattern Signals**: identifies behavior such as overconfident mistakes.
 
-- **Confidence Gap**: The difference between the model's confidence on correct vs. incorrect predictions. A narrow gap signals high diagnostic risk.
-- **High-Confidence Failures**: Automatic flagging of samples where the model was >90% sure but wrong.
-- **Severity Ranking**: Categorizes errors to prioritize manual review.
+Use this module to prioritize error analysis where failure impact is highest.
 
----
+## Bias and Fairness Module
 
-## 3. Bias & Fairness Module
-*Detect performance disparities across subgroups.*
+Fairness diagnostics identify performance disparity between subgroups.
 
-Bias detection reveals performance gaps across sensitive subgroups, helping ensure models are equitable before deployment.
+- **Class Imbalance Report**: distribution imbalance and majority/minority ratios.
+- **Subgroup Performance**: group-wise accuracy and macro-F1 with gap summaries.
+- **Equalized Odds Checks**: group-wise TPR/FPR disparity for binary classification.
 
-- **Subgroup Disparity**: Compares Accuracy, Precision, and Recall across protected attributes (e.g., gender, age).
-- **Equalized Odds**: Checks for parity in False Positive Rates (FPR) and True Positive Rates (TPR) across groups.
-- **Fairness Margin**: A distance-to-limit metric that triggers penalties if disparities exceed acceptable thresholds.
+Use these outputs to detect whether your model systematically underperforms on particular segments.
 
----
+## Representation Module
 
-## 4. Representation Module
-*Audit data integrity and out-of-distribution risks.*
+Representation diagnostics evaluate geometric quality of embeddings when latent vectors are available.
 
-Leverages embeddings to understand if the model is operating on "familiar" ground.
+- **Embedding Separability**: silhouette-based estimate of class separation.
+- **Within/Between Distance Statistics**: distance-based signal for overlap versus separation.
+- **CKA Utility**: centered kernel alignment support for representation similarity studies.
 
-- **Silhouette Scores**: Measures how well-defined the model's feature space is.
-- **OOD Detection**: (Experimental) Identifies samples that fall far from the training representation cluster.
+Representation analysis is optional and only runs when embeddings are provided.
 
----
+## Trust Scoring Engine
 
-## 5. Trust Scoring Engine
-*The unified decision-support signal.*
+The trust scoring engine combines module outputs into one decision support signal.
 
-Aggregates all modules into a single **Trust Score (0-100)** and a **Grade (A-F)**.
+- **Composite Score (0-100)** with a grade and deployment verdict.
+- **Weight Redistribution** when some modules are unavailable.
+- **Risk Penalties** applied for severe calibration, failure, and fairness conditions.
+- **Deployment Blockers** that force a do-not-deploy verdict despite high raw score.
 
-- **Weights**: Configurable importance for each module.
-- **Penalties**: Dynamic deductions based on risk severity.
-- **Blockers**: Automatic "Blocked" verdict if critical thresholds are violated (e.g., severe bias or extreme overconfidence).
+For exact rules, see [Trust Score Explained](trust_score_explained.md).

--- a/docs/guides/ci_deployment_gate.md
+++ b/docs/guides/ci_deployment_gate.md
@@ -1,0 +1,46 @@
+# CI and Deployment Gate Workflow
+
+This guide describes a practical way to use TrustLens outputs as a deployment gate in CI pipelines.
+
+## Goal
+
+Fail fast when a model has high diagnostic risk, even if raw validation accuracy looks good.
+
+## Basic Approach
+
+1. Run model evaluation job.
+2. Generate TrustLens report artifacts.
+3. Parse trust score output in CI.
+4. Enforce policy thresholds (for example score floor and no blockers).
+5. Publish artifacts for review.
+
+## Example Policy
+
+Use a staged policy at first, then tighten:
+
+- Initial phase:
+  - score >= 65
+  - not blocked
+- Mature phase:
+  - score >= 75
+  - not blocked
+  - fairness penalty below defined domain threshold
+
+## Minimal Pattern
+
+```python
+report = analyze(model, X_val, y_val, y_prob=model.predict_proba(X_val))
+report.save("artifacts/trustlens")
+
+if report.trust_score.is_blocked:
+    raise SystemExit("Deployment blocked by TrustLens diagnostics")
+
+if report.trust_score.score < 65:
+    raise SystemExit("Trust score below CI threshold")
+```
+
+## Operational Recommendations
+
+- Keep both machine-readable (`report.json`, `trust_score.json`) and human-readable (`report.txt`) outputs.
+- Do not rely on one threshold alone; include blocker status and penalty context.
+- Store historical scores to detect reliability drift over time.

--- a/docs/guides/fairness_audit_workflow.md
+++ b/docs/guides/fairness_audit_workflow.md
@@ -1,0 +1,54 @@
+# Fairness Audit Workflow
+
+This guide provides a practical fairness-audit flow using TrustLens subgroup and equalized-odds outputs.
+
+## Goal
+
+Detect and triage subgroup performance disparities before deployment decisions.
+
+## Inputs Needed
+
+- `y_true` and model predictions
+- sensitive feature arrays aligned with validation rows
+- binary target labels for equalized-odds checks
+
+## Workflow
+
+1. Define sensitive features (for example gender, age_group, region).
+2. Run analysis with `sensitive_features`.
+3. Inspect subgroup performance gaps.
+4. Inspect equalized-odds violation severity.
+5. Decide whether to proceed, recalibrate, or retrain with mitigation.
+
+## Example
+
+```python
+sensitive = {
+    "gender": gender_val,
+    "age_group": age_group_val,
+}
+
+report = analyze(
+    model,
+    X_val,
+    y_val,
+    y_prob=model.predict_proba(X_val),
+    sensitive_features=sensitive,
+)
+
+report.show()
+```
+
+## Interpretation Checklist
+
+- Which subgroup has the lowest performance?
+- Is performance gap above your policy threshold?
+- Are equalized-odds violations moderate or severe?
+- Is this driven by class imbalance or model behavior?
+
+## Remediation Options
+
+- Data balancing and subgroup-aware sampling
+- Threshold calibration and probability calibration
+- Segment-specific error analysis and feature review
+- Domain review before any production rollout

--- a/docs/guides/model_comparison_workflow.md
+++ b/docs/guides/model_comparison_workflow.md
@@ -1,0 +1,39 @@
+# Model Comparison Workflow
+
+This guide shows how to compare candidate models using TrustLens and select a deployment candidate with explicit risk trade-offs.
+
+## When to Use This
+
+Use this workflow when two or more models have similar accuracy and you need a reliability-first decision.
+
+## Workflow
+
+1. Train candidate models on the same train split.
+2. Run `analyze()` on each model using the same validation data.
+3. Compare trust reports with `compare()`.
+4. Review blocker status, penalties, and dimension-level differences.
+5. Select the candidate with highest safe trust profile, not only highest score.
+
+## Example
+
+```python
+from trustlens import analyze, compare
+
+report_rf = analyze(model_rf, X_val, y_val, y_prob=model_rf.predict_proba(X_val))
+report_lr = analyze(model_lr, X_val, y_val, y_prob=model_lr.predict_proba(X_val))
+
+compare([report_rf, report_lr])
+```
+
+## Decision Checklist
+
+- Are any candidates blocked from deployment?
+- Which model has lower failure penalty burden?
+- Are fairness penalties acceptable for your domain?
+- Is calibration quality sufficient for confidence-based decisions?
+
+## Recommended Output Artifacts
+
+- `report.json` per candidate
+- `trust_score.json` per candidate
+- one short decision memo that captures rationale and rejected alternatives

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,51 +1,83 @@
-# TrustLens: The ML Decision Support System
+# TrustLens Documentation
 
-TrustLens is a production-grade **decision-support system** designed to transform raw model outputs into actionable deployment decisions.
+TrustLens helps ML teams answer a practical question with evidence: should this model be deployed, delayed, or blocked?
 
-Beyond standard accuracy, TrustLens provides a deep, multi-dimensional audit of your model's reliability, safety, and fairness. It bridges the gap between raw metrics and the technical evidence needed to approve (or block) a model for production.
+This documentation is organized around real workflows used by ML engineers, not around internal package structure.
 
-### Core Concepts
-* [**The Problem**](problem.md) — Why accuracy is a dangerous metric for production.
-* [**Who This Is For**](audience.md) — Targeted guidance for MLEs, Data Scientists, and Researchers.
+## Start Here
 
-### Deep Dive
-* [**Features & Modules**](features.md) — Deep dive into Calibration, Failure, Bias, and Representation.
-* [**Real-World Use Cases**](use_cases.md) — Medical AI, Fraud Detection, and Hiring.
-* [**Architecture**](architecture.md) — Modular design and internal logic.
+- New to TrustLens: read [Getting Started](getting_started.md)
+- Need context first: read [Overview](overview.md) and [The Problem](problem.md)
+- Need API details: open [API Reference](api_reference.md)
 
-### Development
-* [**Contributing**](../CONTRIBUTING.md) — How to set up your dev environment.
-* [**Code of Conduct**](../CODE_OF_CONDUCT.md) — Our community standards.
-* [**Roadmap**](../ROADMAP.md) — Future features and project vision.
+## I Want To...
 
----
+- Evaluate one model quickly: [Getting Started](getting_started.md)
+- Understand score logic and verdict rules: [Trust Score Explained](trust_score_explained.md)
+- Investigate reliability and risk dimensions: [Features and Modules](features.md)
+- Use TrustLens in production workflows: [Guides](guides/model_comparison_workflow.md)
+- Understand what is and is not supported: [Known Limitations](known_limitations.md)
+- Extend the system safely: [Architecture](architecture.md), [Contributing](../CONTRIBUTING.md)
 
-<details>
-<summary>🔍 Developer Navigation (Sphinx Only)</summary>
+## Documentation Map
+
+### Foundations
+
+- [Overview](overview.md)
+- [The Problem](problem.md)
+- [Audience](audience.md)
+
+### Concepts
+
+- [Features and Modules](features.md)
+- [Trust Score Explained](trust_score_explained.md)
+- [Known Limitations](known_limitations.md)
+
+### Practical Guides
+
+- [Model Comparison Workflow](guides/model_comparison_workflow.md)
+- [CI and Deployment Gate Workflow](guides/ci_deployment_gate.md)
+- [Fairness Audit Workflow](guides/fairness_audit_workflow.md)
+
+### Reference
+
+- [API Reference](api_reference.md)
+- [Metric: Calibration](metrics/calibration.md)
+- [Metric: Failure](metrics/failure.md)
+- [Metric: Bias](metrics/bias.md)
+- [Metric: Representation](metrics/representation.md)
+
+### Project and Contribution
+
+- [Architecture](architecture.md)
+- [Design Principles](DESIGN_PRINCIPLES.md)
+- [Experimental Modules](EXPERIMENTAL.md)
+- [Contributing Guide](../CONTRIBUTING.md)
+- [Roadmap](../ROADMAP.md)
+- [Code of Conduct](../CODE_OF_CONDUCT.md)
 
 ```{toctree}
 :maxdepth: 2
-:caption: "Contents:"
+:caption: Documentation
 
 getting_started
 overview
-architecture
+problem
+audience
 features
-use_cases
+trust_score_explained
+known_limitations
+guides/model_comparison_workflow
+guides/ci_deployment_gate
+guides/fairness_audit_workflow
 api_reference
-```
-
-```{toctree}
-:maxdepth: 2
-:caption: "Developer Guide:"
-
+architecture
+DESIGN_PRINCIPLES
 EXPERIMENTAL
 ```
 
-## Indices and tables
+## Indices and Tables
 
-* {ref}`genindex`
-* {ref}`modindex`
-* {ref}`search`
-
-</details>
+- {ref}`genindex`
+- {ref}`modindex`
+- {ref}`search`

--- a/docs/known_limitations.md
+++ b/docs/known_limitations.md
@@ -1,0 +1,56 @@
+# Known Limitations
+
+This page documents current limits of TrustLens so users can interpret outputs correctly.
+
+## Scope
+
+TrustLens currently targets classification reliability workflows. Regression support is not a first-class path in the core analysis pipeline.
+
+## Probability Dependency
+
+Calibration and several failure diagnostics require valid probability outputs.
+
+- If your model has no `predict_proba`, you must provide `y_prob` manually.
+- Low-quality probability estimates reduce the quality of trust conclusions.
+
+## Dataset Size Effects
+
+Small validation sets can make calibration and subgroup diagnostics unstable.
+
+- Very small sample sizes may produce noisy ECE and subgroup gap values.
+- Fairness metrics should be interpreted with caution when subgroup counts are low.
+
+## Fairness Constraints
+
+Current equalized-odds logic assumes a binary target and meaningful subgroup diversity.
+
+- If conditions are not met, equalized-odds analysis is skipped.
+- Skipped fairness outputs should not be treated as evidence of fairness.
+
+## Representation Constraints
+
+Representation analysis is optional and depends on embedding quality.
+
+- No embeddings means no representation sub-score.
+- Poorly aligned embeddings can mislead separability interpretation.
+
+## Threshold and Penalty Design
+
+Some trust-score thresholds and penalty boundaries are expert-designed heuristics.
+
+- They are practical defaults, not universal constants.
+- Domain-specific validation is recommended before using hard release gates.
+
+## Not a Causal Fairness Auditor
+
+TrustLens surfaces statistical disparities. It does not prove causality or policy compliance by itself.
+
+- Human review and domain policy checks are still required.
+- Regulatory and legal conclusions should include additional evidence.
+
+## Recommended Mitigations
+
+- Pair score-based gating with manual review for high-impact applications.
+- Validate thresholds on your own datasets before strict automation.
+- Track score behavior over time instead of relying on one run.
+- Preserve full report artifacts for auditability.

--- a/docs/metrics/bias.md
+++ b/docs/metrics/bias.md
@@ -1,9 +1,51 @@
-# Bias & Fairness Metrics
+# Bias and Fairness Metrics
 
-Bias detection reveals performance disparities across sensitive subgroups, helping ensure models are equitable before deployment.
+Bias and fairness metrics expose subgroup disparities so teams can evaluate equity risk before release.
+
+## Why This Matters
+
+A model can look strong in aggregate while underperforming for specific groups.
+Fairness diagnostics make those gaps visible and actionable.
+
+## When to Use
+
+- when model decisions affect people across demographic or policy-sensitive segments
+- when governance requires subgroup performance reporting
+- when release policy includes fairness checks
+
+## Inputs and Assumptions
+
+- `y_true`: ground-truth labels
+- `y_pred`: predicted labels
+- `sensitive_features`: dictionary of aligned subgroup arrays
+- equalized-odds analysis assumes binary target labels
+
+## Output and Interpretation
+
+Key outputs include:
+
+- **Class imbalance report**: class distribution risk context
+- **Subgroup performance**: per-group metrics and gap summaries
+- **Equalized odds summary**: TPR/FPR disparity severity across groups
+
+Large subgroup gaps or severe equalized-odds violations should be treated as release blockers in high-impact domains.
+
+## Limitations and Caveats
+
+- fairness metrics are sensitive to subgroup sample size
+- skipped equalized-odds checks are input constraints, not fairness clearance
+- outputs are statistical diagnostics, not causal proof
+
+## API Reference
 
 ```{eval-rst}
 .. automodule:: trustlens.metrics.bias
    :members:
    :show-inheritance:
 ```
+
+## Related Pages
+
+- [Features and Modules](../features.md)
+- [Known Limitations](../known_limitations.md)
+- [Fairness Audit Workflow](../guides/fairness_audit_workflow.md)

--- a/docs/metrics/calibration.md
+++ b/docs/metrics/calibration.md
@@ -1,9 +1,47 @@
 # Calibration Metrics
 
-Calibration analysis ensures that a model's confidence scores accurately reflect its actual probability of being correct.
+Calibration metrics measure whether confidence values are trustworthy for decision-making.
+
+## Why This Matters
+
+If a model predicts 0.90 confidence, teams often act as if it is correct 90 percent of the time.
+Calibration metrics test whether that assumption is true.
+
+## When to Use
+
+- when confidence values drive downstream thresholds
+- when ranking or triage depends on probability quality
+- when validating reliability before deployment
+
+## Inputs and Assumptions
+
+- `y_true`: ground-truth labels
+- `y_prob`: predicted probabilities
+- calibration utilities are primarily designed for probabilistic classification
+
+## Output and Interpretation
+
+Key outputs include:
+
+- **Brier score**: lower values indicate better probabilistic accuracy
+- **ECE**: lower values indicate confidence is better aligned with observed accuracy
+- **Reliability curve data**: supports visual overconfidence or underconfidence inspection
+
+## Limitations and Caveats
+
+- calibration quality estimates are less stable on very small datasets
+- poor probability estimation upstream can dominate all calibration outputs
+
+## API Reference
 
 ```{eval-rst}
 .. automodule:: trustlens.metrics.calibration
    :members:
    :show-inheritance:
 ```
+
+## Related Pages
+
+- [Features and Modules](../features.md)
+- [Trust Score Explained](../trust_score_explained.md)
+- [Known Limitations](../known_limitations.md)

--- a/docs/metrics/failure.md
+++ b/docs/metrics/failure.md
@@ -1,9 +1,49 @@
-# Failure Analysis
+# Failure Analysis Metrics
 
-This module identifies "diagnostic risk"—the danger of a model being confidently wrong or having a narrow gap between correct and incorrect predictions.
+Failure analysis metrics identify where errors are concentrated and whether error confidence creates operational risk.
+
+## Why This Matters
+
+Two models with similar error rates can have very different risk profiles.
+A model that is highly confident when wrong is usually harder to monitor and safer to block early.
+
+## When to Use
+
+- when incident cost is high for false confidence
+- when investigating model behavior beyond aggregate accuracy
+- when selecting between candidates with close top-line metrics
+
+## Inputs and Assumptions
+
+- `y_true`: ground-truth labels
+- `y_pred`: predicted labels
+- `y_prob`: predicted probabilities
+
+## Output and Interpretation
+
+Key outputs include:
+
+- **Misclassification summary**: class-wise error context
+- **Confidence gap**: separation between confidence on correct versus incorrect predictions
+- **High-confidence error patterns**: useful for targeted inspection
+
+A narrow or negative confidence gap is a warning signal in most operational contexts.
+
+## Limitations and Caveats
+
+- confidence signals depend on quality of upstream probability calibration
+- low error counts can make distribution-level interpretation noisy
+
+## API Reference
 
 ```{eval-rst}
 .. automodule:: trustlens.metrics.failure
    :members:
    :show-inheritance:
 ```
+
+## Related Pages
+
+- [Features and Modules](../features.md)
+- [Trust Score Explained](../trust_score_explained.md)
+- [Known Limitations](../known_limitations.md)

--- a/docs/metrics/representation.md
+++ b/docs/metrics/representation.md
@@ -1,9 +1,49 @@
-# Representation Analysis
+# Representation Metrics
 
-Representation metrics audit data integrity using silhouette scores and embedding cluster analysis.
+Representation metrics evaluate embedding geometry to estimate whether class structure is separable in latent space.
+
+## Why This Matters
+
+Even when aggregate metrics look acceptable, weak latent separation can signal fragile generalization and higher failure risk.
+
+## When to Use
+
+- when embeddings are available from model internals
+- when diagnosing class overlap or feature-space quality
+- when comparing representation quality across model variants
+
+## Inputs and Assumptions
+
+- `embeddings`: latent vectors for each evaluated sample
+- `y_true`: labels aligned with embeddings
+- representation analysis is optional and only runs when embeddings are provided
+
+## Output and Interpretation
+
+Key outputs include:
+
+- **Silhouette score**: higher values indicate better class separation
+- **Within/between class distances**: additional separation signal
+- **CKA utility**: representation similarity support for analysis workflows
+
+Low separability should trigger deeper feature and model diagnostics, not immediate standalone conclusions.
+
+## Limitations and Caveats
+
+- representation quality depends on embedding extraction method
+- silhouette estimates can be unstable with small or highly imbalanced samples
+- representation outputs should be interpreted with calibration and failure diagnostics, not in isolation
+
+## API Reference
 
 ```{eval-rst}
 .. automodule:: trustlens.metrics.representation
    :members:
    :show-inheritance:
 ```
+
+## Related Pages
+
+- [Features and Modules](../features.md)
+- [Known Limitations](../known_limitations.md)
+- [Trust Score Explained](../trust_score_explained.md)

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,34 +1,47 @@
 # Overview
 
-TrustLens is a unified suite for auditing machine learning models, focusing on the gap between "standard accuracy" and "production safety."
+TrustLens is a reliability-focused evaluation layer for classification models. It helps teams move from metric reporting to deployment decisions backed by evidence.
 
-## The Trust Gap
+## Why This Matters
 
-Accuracy is often a poor proxy for real-world reliability. A model can have 95% accuracy while still being:
-- **Unreliable**: Predicting 99% confidence on its mistakes (Overconfidence).
-- **Biased**: Discriminating against sensitive subgroups.
-- **Fragile**: Failing catastrophically on edge cases that it should handle.
+Accuracy alone is often insufficient for production decisions. A model can score high on accuracy while still being unsafe to deploy because of:
 
-TrustLens bridges this "Trust Gap" by providing technical evidence to support a **Deployment Verdict**.
+- overconfident errors
+- subgroup performance disparity
+- weak probability calibration
 
-## Core Pillars
+TrustLens addresses this by combining diagnostic modules and explicit decision logic.
 
-TrustLens evaluates models across four integrated dimensions:
+## What TrustLens Evaluates
 
-### 1. Calibration (Reliability)
-Does a 0.8 probability mean 80% accuracy? We use **Expected Calibration Error (ECE)** and **Brier Scores** to ensure your model's confidence reflects reality.
+TrustLens evaluates models across four dimensions:
 
-### 2. Failure Analysis (Diagnostic Risk)
-Where does your model fail? We identify high-confidence errors and calculate the **Confidence Gap** to quantify how "confidently wrong" your model is.
+- **Calibration**: are predicted probabilities aligned with real outcomes?
+- **Failure behavior**: are errors concentrated in high-confidence regions?
+- **Bias and fairness**: do important subgroups see uneven performance?
+- **Representation quality**: are embeddings well separated when provided?
 
-### 3. Bias & Fairness (Equity)
-Does the model perform equally for everyone? We support **Subgroup Analysis** and **Equalized Odds** to detect and flag hidden disparities.
+These diagnostics are combined into a Trust Score, with penalties and blocker rules applied for high-risk conditions.
 
-### 4. Representation (Data Integrity)
-Is the model seeing "familiar" data? We use **Silhouette Scores** and representation analysis to detect if the training distribution is still relevant to the current inputs.
+## Typical Workflow
 
-## High-Level Workflow
+1. Run `analyze(model, X_val, y_val, y_prob=...)`.
+2. Inspect the returned `TrustReport`.
+3. Review score, blockers, and dimension-level outputs.
+4. Export artifacts for CI, governance, or comparison.
 
-1. **Audit**: Run `analyze(model, X, y)`.
-2. **Score**: Review the **Trust Score** (aggregating results and penalties).
-3. **Decide**: Use the **Verdict** (Deploy, Partial, or Blocked) to inform your CI/CD or governance gates.
+## What You Get
+
+A TrustLens run produces:
+
+- module-level metrics
+- a composite Trust Score with grade and verdict
+- narrative insights and detected risk patterns
+- saveable artifacts for downstream workflows
+
+## Related Pages
+
+- [Getting Started](getting_started.md)
+- [Features and Modules](features.md)
+- [Trust Score Explained](trust_score_explained.md)
+- [Known Limitations](known_limitations.md)

--- a/docs/trust_score_explained.md
+++ b/docs/trust_score_explained.md
@@ -1,0 +1,91 @@
+# Trust Score Explained
+
+This page is the canonical reference for how TrustLens turns diagnostics into a deployment recommendation.
+
+## Why a Composite Score Exists
+
+Raw metrics are useful, but teams still need one final decision signal for release gates and model comparison.  
+TrustLens computes a composite Trust Score from calibration, failure behavior, bias risk, and representation quality.
+
+The score is not meant to replace detailed metrics. It is meant to summarize them for decision making.
+
+## Inputs Used
+
+Trust score logic consumes the module outputs produced by `analyze()`:
+
+- `calibration`: Brier score, ECE
+- `failure`: confidence gap, overall error context
+- `bias`: class imbalance plus subgroup/equalized-odds information
+- `representation`: silhouette-based separability (optional)
+
+## Scoring Workflow
+
+The scoring process has four stages:
+
+1. Compute sub-scores for each available dimension (0 to 100).
+2. Apply dimension weights.
+3. Redistribute weights if some dimensions are missing.
+4. Apply risk penalties and deployment blockers.
+
+This keeps the score usable across different datasets and metadata availability.
+
+## Default Weights
+
+Default weights are:
+
+- Calibration: 0.35
+- Failure: 0.30
+- Bias: 0.25
+- Representation: 0.10
+
+If representation is missing, the other dimensions are re-normalized so total weight remains 1.0.
+
+## Penalties
+
+TrustLens applies deductions when severe risk signals are detected. These penalties are intended to stop the final score from hiding critical issues behind good average performance.
+
+Examples of penalty triggers:
+
+- Failure sub-score falls below a safety threshold
+- ECE exceeds calibration tolerance
+- Fairness violations exceed subgroup disparity limits
+
+The final penalty burden is capped to preserve score interpretability.
+
+## Deployment Blockers
+
+Some conditions produce an explicit deployment block even when the numeric score is moderate.
+
+Typical blockers include:
+
+- Strong confidently-wrong behavior
+- Severe fairness violations
+- Very poor calibration quality
+
+When blocked, verdict messaging is forced into a do-not-deploy stance.
+
+## Grade Interpretation
+
+TrustLens maps final score to grade bands:
+
+- A: high trust, production-ready profile
+- B: good trust, minor issues to address
+- C: moderate trust, investigate before deployment
+- D: low trust, deployment should be blocked
+
+Blockers can force a low-trust verdict regardless of grade boundaries.
+
+## How to Use This in Practice
+
+- Use the score for ranking and release gating.
+- Use sub-scores to identify which dimension needs work.
+- Use penalty details for remediation priorities.
+- Use full metric pages for root-cause analysis.
+
+## Related Reading
+
+- [Features and Modules](features.md)
+- [Known Limitations](known_limitations.md)
+- [Metric: Calibration](metrics/calibration.md)
+- [Metric: Failure](metrics/failure.md)
+- [Metric: Bias](metrics/bias.md)

--- a/docs/trust_score_explained.md
+++ b/docs/trust_score_explained.md
@@ -4,7 +4,7 @@ This page is the canonical reference for how TrustLens turns diagnostics into a 
 
 ## Why a Composite Score Exists
 
-Raw metrics are useful, but teams still need one final decision signal for release gates and model comparison.  
+Raw metrics are useful, but teams still need one final decision signal for release gates and model comparison.
 TrustLens computes a composite Trust Score from calibration, failure behavior, bias risk, and representation quality.
 
 The score is not meant to replace detailed metrics. It is meant to summarize them for decision making.

--- a/docs/use_cases.md
+++ b/docs/use_cases.md
@@ -1,25 +1,61 @@
 # Real-World Use Cases
 
-TrustLens is applied across industries to ensure model safety and governance.
+This page shows how TrustLens is used in practical decision points where accuracy alone is not enough.
 
----
+## How to Read These Examples
 
-## 1. Safety-Critical Selection (Medical AI)
-**Scenario**: Choosing between a 94% accurate "Black Box" model and a 92% accurate well-calibrated model.
-- **TrustLens Output**: Identifies that the 94% model has high Expected Calibration Error (ECE), making its probability scores unreliable for triage.
-- **Verdict**: Recommend the 92% model due to superior calibration and reliability.
+Each use case has three parts:
 
-## 2. Model Governance & Compliance
-**Scenario**: Auditing financial models for bias before submission to regulators.
-- **TrustLens Output**: Automatically identifies performance gaps in `Equalized Odds` for sensitive protected attributes.
-- **Verdict**: Flag model as "Blocked" due to fairness violations, providing clear evidence for retraining.
+- **Scenario**: the production decision context
+- **Diagnostic signal**: what TrustLens surfaces
+- **Decision impact**: what action follows
 
-## 3. High-Throughput Maintenance
-**Scenario**: Monitoring if a deployed model is starting to "drift" or become overconfident on new data.
-- **TrustLens Output**: Detects a shrinking `Confidence Gap` over time, indicating the model is becoming less reliable at separating correct from incorrect predictions.
-- **Verdict**: Trigger a manual review of the last 1000 samples.
+## Safety-Critical Model Selection
 
-## 4. Head-to-Head Comparison
-**Scenario**: Testing three different candidate models for a production vacancy.
-- **TrustLens Output**: A ranked comparison dashboard showing which model has the cleanest aggregate Trust Score.
-- **Verdict**: Select the model with the lowest penalty burden, even if its raw accuracy is marginally lower than competitors.
+**Scenario**
+You must choose between a higher-accuracy model and a slightly lower-accuracy but better-calibrated model.
+
+**Diagnostic signal**
+Calibration outputs indicate that the higher-accuracy model has materially higher ECE and less reliable confidence.
+
+**Decision impact**
+Prefer the model with safer confidence behavior for triage-heavy workflows.
+
+## Governance and Fairness Review
+
+**Scenario**
+A model must pass internal fairness review before release.
+
+**Diagnostic signal**
+Subgroup gap and equalized-odds outputs show severe disparity for one sensitive feature.
+
+**Decision impact**
+Treat release as blocked until disparity is investigated and mitigated.
+
+## Post-Deployment Reliability Monitoring
+
+**Scenario**
+A deployed model still meets top-line accuracy targets, but support teams report suspicious errors.
+
+**Diagnostic signal**
+Confidence gap trends shrink over time and high-confidence mistakes increase.
+
+**Decision impact**
+Trigger focused error review and retraining or recalibration cycle.
+
+## Candidate Ranking for Release
+
+**Scenario**
+Several candidates pass baseline accuracy and latency targets.
+
+**Diagnostic signal**
+`compare()` shows one candidate has lower penalty burden and no blockers.
+
+**Decision impact**
+Select the safer candidate, even if raw accuracy is slightly lower.
+
+## Related Pages
+
+- [Model Comparison Workflow](guides/model_comparison_workflow.md)
+- [CI and Deployment Gate Workflow](guides/ci_deployment_gate.md)
+- [Fairness Audit Workflow](guides/fairness_audit_workflow.md)


### PR DESCRIPTION
## Summary

This PR upgrades TrustLens documentation from a set of standalone pages into a coherent handbook for practitioners.

### What changed

- Reworked `docs/index.md` into a task-oriented documentation hub
- Added canonical decision references:
  - `docs/trust_score_explained.md`
  - `docs/known_limitations.md`
- Added workflow guides:
  - `docs/guides/model_comparison_workflow.md`
  - `docs/guides/ci_deployment_gate.md`
  - `docs/guides/fairness_audit_workflow.md`
- Added `docs/PAGE_TEMPLATE.md` for consistent future doc authoring
- Harmonized wording and structure across:
  - `docs/overview.md`
  - `docs/use_cases.md`
  - `docs/architecture.md`
  - `docs/metrics/calibration.md`
  - `docs/metrics/failure.md`
  - `docs/metrics/bias.md`
  - `docs/metrics/representation.md`
- Refined `README.md` as a stronger landing page and restored contributor wall

### Why

The previous docs had good content but varied voice and page structure.  
This update makes onboarding, trust-score interpretation, and production usage clearer for ML engineers, while making the full docs set read as one handbook.

## Test Plan

- [x] Verified markdown edits render correctly in repo files
- [x] Confirmed documentation links and cross-references are internally consistent
- [x] Checked edited files for lint issues via Cursor diagnostics (no errors)

## Impact

- Improves first-time adoption experience
- Improves documentation maintainability with a reusable page template
- Aligns README + docs with a single product narrative