### PR TITLE
feat(bias): add validation, configurable thresholds and docstring exa…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pattern detection system (e.g., "Calibration Drift", "Confidently Wrong") to surface high-level semantic risks.
 - Initial `equalized_odds()` fairness metric with per-group TPR/FPR analysis (closes #17). Thanks @komoike-oss28-ui
 - Ranked score explanation layer to justify Trust Score deductions.
+- `equalized_odds()`: added input validation, configurable violation thresholds (`severe_threshold`, `moderate_threshold`), and concrete docstring examples (closes #41)
 
 ### Improved
 - Final Trust Score logic now includes a base score, penalty breakdown, and decisive deployment verdicts.

--- a/tests/test_bias.py
+++ b/tests/test_bias.py
@@ -168,3 +168,88 @@ class TestEqualizedOdds:
         result = equalized_odds(y_true, y_pred, sensitive_features={"group": group})
         assert result["group"]["0"]["n_samples"] == 3
         assert result["group"]["1"]["n_samples"] == 2
+
+    # --- New tests for issue #41 ---
+
+    def test_custom_thresholds_moderate(self):
+        """Custom thresholds: gap that is 'severe' by default becomes 'moderate'."""
+        y_true = np.array([1, 1, 0, 0, 1, 1, 0, 0])
+        y_pred = np.array([1, 0, 0, 0, 1, 1, 1, 0])
+        gender = np.array([0, 0, 0, 0, 1, 1, 1, 1])
+
+        # tpr_gap=0.5, with severe_threshold=0.6 this should be 'moderate'
+        result = equalized_odds(
+            y_true,
+            y_pred,
+            sensitive_features={"gender": gender},
+            severe_threshold=0.6,
+            moderate_threshold=0.1,
+        )
+        assert result["gender"]["__summary__"]["tpr_violation"] == "moderate"
+
+    def test_custom_thresholds_acceptable(self):
+        """Custom thresholds: gap that is 'moderate' by default becomes 'acceptable'."""
+        y_true = np.array([1, 0, 1, 0])
+        y_pred = np.array([1, 0, 1, 0])
+        group = np.array([0, 0, 1, 1])
+
+        result = equalized_odds(
+            y_true,
+            y_pred,
+            sensitive_features={"group": group},
+            severe_threshold=0.3,
+            moderate_threshold=0.1,
+        )
+        assert result["group"]["__summary__"]["tpr_violation"] == "acceptable"
+
+    def test_default_thresholds_unchanged(self):
+        """Default thresholds remain 0.15 / 0.05 — backward compatible."""
+        y_true = np.array([1, 1, 0, 0, 1, 1, 0, 0])
+        y_pred = np.array([1, 0, 0, 0, 1, 1, 1, 0])
+        gender = np.array([0, 0, 0, 0, 1, 1, 1, 1])
+
+        result = equalized_odds(y_true, y_pred, sensitive_features={"gender": gender})
+        assert result["gender"]["__summary__"]["tpr_violation"] == "severe"
+
+    def test_validation_empty_arrays(self):
+        """Empty y_true / y_pred should raise ValueError."""
+        with pytest.raises(ValueError, match="must not be empty"):
+            equalized_odds(np.array([]), np.array([]), {"group": np.array([])})
+
+    def test_validation_length_mismatch_y(self):
+        """Mismatched y_true and y_pred lengths should raise ValueError."""
+        with pytest.raises(ValueError, match="same length"):
+            equalized_odds(
+                np.array([1, 0, 1]),
+                np.array([1, 0]),
+                {"group": np.array([0, 0, 1])},
+            )
+
+    def test_validation_length_mismatch_feature(self):
+        """Mismatched sensitive_features length should raise ValueError."""
+        with pytest.raises(ValueError, match="sensitive_features"):
+            equalized_odds(
+                np.array([1, 0, 1, 0]),
+                np.array([1, 0, 1, 0]),
+                {"group": np.array([0, 1])},  # wrong length
+            )
+
+    def test_validation_invalid_thresholds(self):
+        """moderate_threshold >= severe_threshold should raise ValueError."""
+        with pytest.raises(ValueError, match="Thresholds must satisfy"):
+            equalized_odds(
+                np.array([1, 0, 1, 0]),
+                np.array([1, 0, 1, 0]),
+                {"group": np.array([0, 0, 1, 1])},
+                severe_threshold=0.05,
+                moderate_threshold=0.15,
+            )
+
+    def test_validation_empty_sensitive_features(self):
+        """Empty sensitive_features dict should raise ValueError."""
+        with pytest.raises(ValueError, match="sensitive_features must not be empty"):
+            equalized_odds(
+                np.array([1, 0, 1, 0]),
+                np.array([1, 0, 1, 0]),
+                {},
+            )

--- a/trustlens/metrics/bias.py
+++ b/trustlens/metrics/bias.py
@@ -168,6 +168,8 @@ def equalized_odds(
     y_true: np.ndarray,
     y_pred: np.ndarray,
     sensitive_features: dict[str, np.ndarray],
+    severe_threshold: float = 0.15,
+    moderate_threshold: float = 0.05,
 ) -> dict:
     """
     Compute Equalized Odds fairness metrics broken down by sensitive subgroups.
@@ -182,12 +184,18 @@ def equalized_odds(
     Parameters
     ----------
     y_true : np.ndarray
-        Ground-truth binary labels.
+        Ground-truth binary labels (0 or 1).
     y_pred : np.ndarray
-        Model predictions (binary).
+        Model predictions (binary, 0 or 1).
     sensitive_features : dict
         Mapping of feature name → 1-D array of group labels.
         Example: ``{"gender": gender_array}``.
+    severe_threshold : float, optional
+        Gap above which a violation is classified as ``"severe"``.
+        Default: ``0.15``.
+    moderate_threshold : float, optional
+        Gap above which a violation is classified as ``"moderate"``.
+        Must be less than ``severe_threshold``. Default: ``0.05``.
 
     Returns
     -------
@@ -208,21 +216,68 @@ def equalized_odds(
           * ``worst_tpr_group``  — group with lowest TPR
 
         Violation levels:
-          * ``"severe"``     — gap > 0.15
-          * ``"moderate"``   — gap between 0.05 and 0.15
-          * ``"acceptable"`` — gap < 0.05
+          * ``"severe"``     — gap > severe_threshold (default 0.15)
+          * ``"moderate"``   — gap between moderate_threshold and severe_threshold
+          * ``"acceptable"`` — gap < moderate_threshold (default 0.05)
+
+    Raises
+    ------
+    ValueError
+        If ``y_true`` and ``y_pred`` have different lengths.
+    ValueError
+        If any ``sensitive_features`` array has a different length than ``y_true``.
+    ValueError
+        If ``moderate_threshold`` >= ``severe_threshold``.
+    ValueError
+        If ``y_true`` or ``y_pred`` is empty.
 
     Examples
     --------
-    >>> results = equalized_odds(
-    ...     y_true, y_pred,
-    ...     sensitive_features={"gender": gender_array},
-    ... )
-    >>> print(results["gender"]["__summary__"]["tpr_violation"])
+    >>> import numpy as np
+    >>> from trustlens.metrics.bias import equalized_odds
+    >>>
+    >>> y_true = np.array([1, 1, 0, 0, 1, 1, 0, 0])
+    >>> y_pred = np.array([1, 0, 0, 0, 1, 1, 1, 0])
+    >>> gender  = np.array([0, 0, 0, 0, 1, 1, 1, 1])
+    >>>
+    >>> results = equalized_odds(y_true, y_pred, {"gender": gender})
+    >>> results["gender"]["0"]
+    {'n_samples': 4, 'tpr': 0.5, 'fpr': 0.0}
+    >>> results["gender"]["1"]
+    {'n_samples': 4, 'tpr': 1.0, 'fpr': 0.5}
+    >>> results["gender"]["__summary__"]
+    {'tpr_gap': 0.5, 'fpr_gap': 0.5, 'tpr_violation': 'severe', 'fpr_violation': 'severe', 'best_tpr_group': '1', 'worst_tpr_group': '0'}
     """
+    # --- Input validation ---
     y_true = np.asarray(y_true)
     y_pred = np.asarray(y_pred)
 
+    if len(y_true) == 0 or len(y_pred) == 0:
+        raise ValueError("y_true and y_pred must not be empty.")
+
+    if len(y_true) != len(y_pred):
+        raise ValueError(
+            f"y_true and y_pred must have the same length, got {len(y_true)} and {len(y_pred)}."
+        )
+
+    if not (0.0 < moderate_threshold < severe_threshold < 1.0):
+        raise ValueError(
+            f"Thresholds must satisfy 0 < moderate_threshold < severe_threshold < 1, "
+            f"got moderate_threshold={moderate_threshold}, severe_threshold={severe_threshold}."
+        )
+
+    if not sensitive_features:
+        raise ValueError("sensitive_features must not be empty.")
+
+    for feature_name, group_array in sensitive_features.items():
+        group_array = np.asarray(group_array)
+        if len(group_array) != len(y_true):
+            raise ValueError(
+                f"sensitive_features['{feature_name}'] has length {len(group_array)}, "
+                f"expected {len(y_true)}."
+            )
+
+    # --- Core computation ---
     report: dict = {}
 
     for feature_name, group_array in sensitive_features.items():
@@ -270,8 +325,8 @@ def equalized_odds(
         group_results["__summary__"] = {
             "tpr_gap": tpr_gap,
             "fpr_gap": fpr_gap,
-            "tpr_violation": _violation_level(tpr_gap),
-            "fpr_violation": _violation_level(fpr_gap),
+            "tpr_violation": _violation_level(tpr_gap, severe_threshold, moderate_threshold),
+            "fpr_violation": _violation_level(fpr_gap, severe_threshold, moderate_threshold),
             "best_tpr_group": best_tpr_group,
             "worst_tpr_group": worst_tpr_group,
         }
@@ -281,11 +336,13 @@ def equalized_odds(
     return report
 
 
-def _violation_level(gap: float) -> str:
+def _violation_level(
+    gap: float, severe_threshold: float = 0.15, moderate_threshold: float = 0.05
+) -> str:
     """Classify a fairness gap into a violation severity level."""
-    if gap > 0.15:
+    if gap > severe_threshold:
         return "severe"
-    elif gap >= 0.05:
+    elif gap >= moderate_threshold:
         return "moderate"
     else:
         return "acceptable"


### PR DESCRIPTION
## Summary
Follow-up improvements to `equalized_odds()` as discussed in #38 review.
Adds input validation, configurable violation thresholds, and concrete docstring examples.

## Related Issue
Closes #41

## Type of Change
- [x] 🚀 New feature (non-breaking change which adds functionality)

## Changes Made
- [x] Added input validation (empty arrays, length mismatch, invalid thresholds, empty sensitive_features)
- [x] Added `severe_threshold` and `moderate_threshold` parameters (defaults: 0.15 / 0.05 — fully backward compatible)
- [x] Added concrete docstring example showing input/output format
- [x] Added 8 new tests to `TestEqualizedOdds` in `tests/test_bias.py`
- [x] Updated `CHANGELOG.md` under `[Unreleased]`

## Testing
- [x] All unit tests pass locally.
- [x] Added new tests for the changes made.

## Pre-submit Checklist
- [x] Run `pre-commit run --all-files` and all hooks passed.
- [x] Verified that all tests pass (`make test`).
- [x] Updated the `CHANGELOG.md` if applicable.
- [x] Verified that documentation has been updated for new features.

## Notes for Reviewers
All changes are fully backward compatible — default threshold values (0.15 / 0.05) match the original implementation.