### PR TITLE
Feat: add multi_feature parameter to TrustReport.plot_bias() (#74)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `_BIAS_PLOT_TYPES` — internal registry for deterministic plot-type dispatch ordering in `_plot_bias()`.
 - `tests/conftest.py` — centralized Agg backend configuration for the test suite.
 - `tests/test_plot_module_multi_feature.py` — 23 integration tests covering nested figure outputs, filename sanitization, orchestrated saving, and edge cases.
+- `TrustReport.plot_bias()` now accepts an opt-in `multi_feature: bool = False` parameter for per-feature visualization output. With `multi_feature=True`, single modes (`"subgroup"`, `"equalized_odds"`, `"gap"`) return `dict[str, Figure]` keyed by feature name, and `mode="all"` returns a nested `dict[str, dict[str, Figure]]` keyed by mode then feature. The structure is fixed by the `(mode, multi_feature)` combination, missing components are represented by empty dicts (never `None`), and feature ordering is deterministic (`sorted(feature_names)`). Default behavior (`multi_feature=False`) is unchanged. `tests/test_plot_bias_multi_feature.py` adds 18 tests covering the four return-shape cells, partial-data handling, deterministic ordering, and invalid-mode interaction (closes #74). Thanks @komoike-oss28-ui
 
 ### Improved
 - Final Trust Score logic now includes a base score, penalty breakdown, and decisive deployment verdicts.

--- a/tests/test_plot_bias_multi_feature.py
+++ b/tests/test_plot_bias_multi_feature.py
@@ -1,0 +1,296 @@
+"""
+tests/test_plot_bias_multi_feature.py.
+======================================
+Tests for the ``multi_feature`` parameter of ``TrustReport.plot_bias()``.
+
+These tests cover the four cells of the ``(mode, multi_feature)`` return-shape
+table, partial-data handling, deterministic ordering, and the interaction
+between ``multi_feature=True`` and an invalid ``mode``.
+"""
+
+from unittest.mock import MagicMock
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+from trustlens.report import TrustReport
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_report(bias_data: dict) -> TrustReport:
+    """Build a minimal TrustReport whose bias module holds ``bias_data``."""
+    model = MagicMock()
+    X = np.zeros((10, 2))
+    y_true = np.array([0, 1] * 5)
+    y_pred = np.array([0, 1] * 5)
+    y_prob = np.random.rand(10, 2)
+    return TrustReport({"bias": bias_data}, model, X, y_true, y_pred, y_prob)
+
+
+@pytest.fixture
+def multi_feature_bias_data() -> dict:
+    """Bias data with two sensitive features (gender, age) on both modes."""
+    return {
+        "subgroup_performance": {
+            "gender": {
+                "male": {"accuracy": 0.82, "f1": 0.80},
+                "female": {"accuracy": 0.70, "f1": 0.68},
+                "__summary__": {"performance_gap": 0.12},
+            },
+            "age": {
+                "young": {"accuracy": 0.79, "f1": 0.77},
+                "old": {"accuracy": 0.65, "f1": 0.63},
+                "__summary__": {"performance_gap": 0.14},
+            },
+        },
+        "equalized_odds": {
+            "gender": {
+                "male": {"tpr": 0.80, "fpr": 0.10},
+                "female": {"tpr": 0.65, "fpr": 0.20},
+                "__summary__": {
+                    "tpr_gap": 0.15,
+                    "fpr_gap": 0.10,
+                    "tpr_violation": "moderate",
+                    "fpr_violation": "acceptable",
+                },
+            },
+            "age": {
+                "young": {"tpr": 0.78, "fpr": 0.12},
+                "old": {"tpr": 0.60, "fpr": 0.25},
+                "__summary__": {
+                    "tpr_gap": 0.18,
+                    "fpr_gap": 0.13,
+                    "tpr_violation": "moderate",
+                    "fpr_violation": "moderate",
+                },
+            },
+        },
+    }
+
+
+@pytest.fixture
+def multi_feature_report(multi_feature_bias_data) -> TrustReport:
+    return _make_report(multi_feature_bias_data)
+
+
+# ---------------------------------------------------------------------------
+# 1. Return-shape matrix: four (mode, multi_feature) cells
+# ---------------------------------------------------------------------------
+
+
+class TestReturnShapeMatrix:
+    """Cover the four cells of the (mode, multi_feature) return-shape table."""
+
+    def test_single_mode_multi_feature_false_returns_figure(self, multi_feature_report):
+        """Single mode + multi_feature=False -> Figure (current behavior)."""
+        for mode in ("subgroup", "equalized_odds", "gap"):
+            fig = multi_feature_report.plot_bias(mode=mode, multi_feature=False, show=False)
+            assert isinstance(fig, plt.Figure), f"mode={mode} did not return a Figure"
+
+    def test_single_mode_multi_feature_true_returns_dict_of_figures(self, multi_feature_report):
+        """Single mode + multi_feature=True -> dict[str, Figure] keyed by feature."""
+        for mode in ("subgroup", "equalized_odds", "gap"):
+            result = multi_feature_report.plot_bias(mode=mode, multi_feature=True, show=False)
+            assert isinstance(result, dict), f"mode={mode} did not return a dict"
+            assert set(result.keys()) == {"gender", "age"}
+            for feat, fig in result.items():
+                assert isinstance(fig, plt.Figure), f"mode={mode}, feature={feat}: not a Figure"
+
+    def test_all_mode_multi_feature_false_returns_dict_of_figures(self, multi_feature_report):
+        """mode='all' + multi_feature=False -> dict[mode, Figure] (current behavior)."""
+        result = multi_feature_report.plot_bias(mode="all", multi_feature=False, show=False)
+        assert isinstance(result, dict)
+        assert set(result.keys()) == {"subgroup", "equalized_odds", "gap"}
+        for fig in result.values():
+            assert isinstance(fig, plt.Figure)
+
+    def test_all_mode_multi_feature_true_returns_nested_dict(self, multi_feature_report):
+        """mode='all' + multi_feature=True -> dict[mode, dict[feature, Figure]]."""
+        result = multi_feature_report.plot_bias(mode="all", multi_feature=True, show=False)
+        assert isinstance(result, dict)
+        assert set(result.keys()) == {"subgroup", "equalized_odds", "gap"}
+        for mode_key, inner in result.items():
+            assert isinstance(inner, dict), f"{mode_key} value is not a dict"
+            assert set(inner.keys()) == {"gender", "age"}
+            for fig in inner.values():
+                assert isinstance(fig, plt.Figure)
+
+
+# ---------------------------------------------------------------------------
+# 2. summary + multi_feature=True passthrough (spec 1)
+# ---------------------------------------------------------------------------
+
+
+class TestSummaryMultiFeaturePassthrough:
+    """``summary`` mode with ``multi_feature=True`` must behave identically
+    to ``multi_feature=False`` (a feature-agnostic summary view)."""
+
+    def test_summary_multi_true_matches_summary_multi_false_type(self, multi_feature_report):
+        result_false = multi_feature_report.plot_bias(
+            mode="summary", multi_feature=False, show=False
+        )
+        result_true = multi_feature_report.plot_bias(mode="summary", multi_feature=True, show=False)
+        # Both must produce the same return *type* (single-figure flow);
+        # this is the "pass-through" guarantee from the spec.
+        assert type(result_false) is type(result_true)
+
+
+# ---------------------------------------------------------------------------
+# 3. Partial / missing data
+# ---------------------------------------------------------------------------
+
+
+class TestPartialDataHandling:
+    """When some bias components are missing, the structure must be
+    preserved and missing slots must be ``{}`` (never ``None``)."""
+
+    def test_all_multi_only_subgroup_present(self, multi_feature_bias_data):
+        """Only subgroup_performance available."""
+        bias = {"subgroup_performance": multi_feature_bias_data["subgroup_performance"]}
+        report = _make_report(bias)
+        result = report.plot_bias(mode="all", multi_feature=True, show=False)
+
+        assert set(result.keys()) == {"subgroup", "equalized_odds", "gap"}
+        assert set(result["subgroup"].keys()) == {"gender", "age"}
+        # No equalized_odds data -> empty dict, not None
+        assert result["equalized_odds"] == {}
+        # 'gap' falls back to subgroup_performance, so it is populated
+        assert set(result["gap"].keys()) == {"gender", "age"}
+
+    def test_all_multi_only_equalized_odds_present(self, multi_feature_bias_data):
+        """Only equalized_odds available."""
+        bias = {"equalized_odds": multi_feature_bias_data["equalized_odds"]}
+        report = _make_report(bias)
+        result = report.plot_bias(mode="all", multi_feature=True, show=False)
+
+        assert set(result.keys()) == {"subgroup", "equalized_odds", "gap"}
+        assert result["subgroup"] == {}
+        assert set(result["equalized_odds"].keys()) == {"gender", "age"}
+        # 'gap' falls back to equalized_odds when subgroup is absent
+        assert set(result["gap"].keys()) == {"gender", "age"}
+
+    def test_all_multi_no_values_are_none(self, multi_feature_bias_data):
+        """Every value at every level of the return must be a dict or Figure;
+        explicitly never ``None``."""
+        bias = {"subgroup_performance": multi_feature_bias_data["subgroup_performance"]}
+        report = _make_report(bias)
+        result = report.plot_bias(mode="all", multi_feature=True, show=False)
+
+        for mode_key, inner in result.items():
+            assert inner is not None, f"{mode_key} is None"
+            assert isinstance(inner, dict)
+            for feat_key, fig in inner.items():
+                assert fig is not None, f"{mode_key}/{feat_key} is None"
+                assert isinstance(fig, plt.Figure)
+
+    def test_single_mode_multi_true_missing_data_raises(self, multi_feature_bias_data):
+        """If a single mode is requested with multi_feature=True but the
+        relevant data is missing, ValueError is raised — same contract as
+        the single-feature path."""
+        # Only equalized_odds present -> 'subgroup' single mode must raise
+        bias = {"equalized_odds": multi_feature_bias_data["equalized_odds"]}
+        report = _make_report(bias)
+        with pytest.raises(ValueError, match="subgroup_performance"):
+            report.plot_bias(mode="subgroup", multi_feature=True, show=False)
+
+    def test_no_bias_module_raises_with_multi_feature(self):
+        """Bias module missing entirely -> ValueError regardless of multi_feature."""
+        model = MagicMock()
+        X = np.zeros((10, 2))
+        y_true = np.array([0, 1] * 5)
+        y_pred = np.array([0, 1] * 5)
+        y_prob = np.random.rand(10, 2)
+        report = TrustReport({}, model, X, y_true, y_pred, y_prob)
+        with pytest.raises(ValueError, match="Bias results not available"):
+            report.plot_bias(mode="all", multi_feature=True, show=False)
+
+
+# ---------------------------------------------------------------------------
+# 4. Deterministic ordering
+# ---------------------------------------------------------------------------
+
+
+class TestDeterministicOrdering:
+    """Mode and feature ordering must be deterministic and independent of
+    the original dict insertion order."""
+
+    def test_all_multi_mode_keys_in_canonical_order(self, multi_feature_report):
+        """Mode keys must appear in subgroup -> equalized_odds -> gap order."""
+        result = multi_feature_report.plot_bias(mode="all", multi_feature=True, show=False)
+        assert list(result.keys()) == ["subgroup", "equalized_odds", "gap"]
+
+    def test_feature_keys_are_sorted(self, multi_feature_report):
+        """Feature keys must be in ``sorted()`` order — alphabetical, not
+        insertion order ('gender' was inserted before 'age')."""
+        result = multi_feature_report.plot_bias(mode="all", multi_feature=True, show=False)
+        for mode_key, inner in result.items():
+            assert list(inner.keys()) == sorted(inner.keys()), (
+                f"{mode_key} feature keys are not sorted: {list(inner.keys())}"
+            )
+            # Concretely: alphabetical -> 'age' before 'gender'
+            assert list(inner.keys()) == ["age", "gender"]
+
+    def test_single_mode_multi_feature_keys_are_sorted(self, multi_feature_report):
+        """Single-mode multi_feature output must also use sorted feature order."""
+        for mode in ("subgroup", "equalized_odds", "gap"):
+            result = multi_feature_report.plot_bias(mode=mode, multi_feature=True, show=False)
+            assert list(result.keys()) == ["age", "gender"], (
+                f"mode={mode}: keys not in sorted order: {list(result.keys())}"
+            )
+
+    def test_repeated_calls_stable(self, multi_feature_report):
+        """Repeated calls must produce identical key orderings."""
+        r1 = multi_feature_report.plot_bias(mode="all", multi_feature=True, show=False)
+        r2 = multi_feature_report.plot_bias(mode="all", multi_feature=True, show=False)
+        assert list(r1.keys()) == list(r2.keys())
+        for mode_key in r1:
+            assert list(r1[mode_key].keys()) == list(r2[mode_key].keys())
+
+
+# ---------------------------------------------------------------------------
+# 5. Invalid mode + multi_feature=True
+# ---------------------------------------------------------------------------
+
+
+class TestInvalidModeWithMultiFeature:
+    """``multi_feature=True`` must not bypass the ``mode`` validation."""
+
+    def test_invalid_mode_with_multi_feature_true_raises(self, multi_feature_report):
+        with pytest.raises(ValueError, match="Invalid mode"):
+            multi_feature_report.plot_bias(mode="bogus", multi_feature=True, show=False)
+
+    def test_invalid_mode_with_multi_feature_false_still_raises(self, multi_feature_report):
+        """Sanity check: same error path is reachable with the default."""
+        with pytest.raises(ValueError, match="Invalid mode"):
+            multi_feature_report.plot_bias(mode="bogus", multi_feature=False, show=False)
+
+
+# ---------------------------------------------------------------------------
+# 6. Backward compatibility
+# ---------------------------------------------------------------------------
+
+
+class TestBackwardCompatibility:
+    """The default (``multi_feature=False``) must be unchanged."""
+
+    def test_default_call_unchanged(self, multi_feature_report):
+        """Default call (no mode, no multi_feature) must still work as before."""
+        # Just ensure it does not raise; type can be Figure or dict depending on
+        # how _plot_bias() summarises the data — this is the existing contract.
+        result = multi_feature_report.plot_bias(show=False)
+        assert result is not None
+
+    def test_multi_feature_default_is_false(self, multi_feature_report):
+        """Calling without ``multi_feature`` must equal calling with ``False``."""
+        for mode in ("subgroup", "equalized_odds", "gap"):
+            r_default = multi_feature_report.plot_bias(mode=mode, show=False)
+            r_explicit = multi_feature_report.plot_bias(mode=mode, multi_feature=False, show=False)
+            assert type(r_default) is type(r_explicit)
+            assert isinstance(r_default, plt.Figure)

--- a/tests/test_plot_bias_multi_feature.py
+++ b/tests/test_plot_bias_multi_feature.py
@@ -10,9 +10,6 @@ between ``multi_feature=True`` and an invalid ``mode``.
 
 from unittest.mock import MagicMock
 
-import matplotlib
-
-matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest

--- a/trustlens/report.py
+++ b/trustlens/report.py
@@ -835,68 +835,117 @@ class TrustReport:
         mode: str = "summary",
         show: bool = True,
         save_path: str | None = None,
+        multi_feature: bool = False,
     ):
         """
         Generate fairness/bias visualizations from report results.
 
+        ``mode`` and ``multi_feature`` are independent dimensions; the return
+        shape is fully determined by their combination, with no flattening.
+
         Guarantees:
-        - Returns matplotlib.figure.Figure (single modes)
-        - Returns dict[str, matplotlib.figure.Figure | None] (mode="all")
-        - Raises ValueError for invalid mode or unusable data
+        - Return shape is fixed by the ``(mode, multi_feature)`` combination
+          (see the table below). The structure never collapses across calls.
+        - Multi-feature outputs never contain ``None`` values; missing
+          components are represented by empty dicts ``{}``.
+        - Raises ``ValueError`` for invalid ``mode`` or unusable data, regardless
+          of ``multi_feature``.
 
-        Returned dict for mode="all" ALWAYS contains exactly three keys in order:
-        'subgroup' -> 'equalized_odds' -> 'gap'. Values may be None if a plot
-        cannot be generated. Individual plot failures in mode="all" are silent
-        (no exception, no logging; values set to None). If all plots fail (all
-        values None), raise ValueError. Caller is responsible for checking
-        None values in returned dict.
+        Return shape by ``(mode, multi_feature)``:
 
-        Note: mode="all" returns a dictionary of plots and does NOT display them
-        unless show=True.
+        +-----------------+----------------+--------------------------------------+
+        | mode            | multi_feature  | Return type                          |
+        +=================+================+======================================+
+        | single mode     | False          | ``Figure``                           |
+        | (summary,       |                |                                      |
+        | subgroup,       |                |                                      |
+        | equalized_odds, |                |                                      |
+        | gap)            |                |                                      |
+        +-----------------+----------------+--------------------------------------+
+        | summary         | True           | ``Figure`` (same as ``False``)       |
+        +-----------------+----------------+--------------------------------------+
+        | subgroup,       | True           | ``dict[str, Figure]`` keyed by       |
+        | equalized_odds, |                | feature name (sorted)                |
+        | gap             |                |                                      |
+        +-----------------+----------------+--------------------------------------+
+        | all             | False          | ``dict[str, Figure | None]`` keyed   |
+        |                 |                | by mode (existing behavior)          |
+        +-----------------+----------------+--------------------------------------+
+        | all             | True           | ``dict[str, dict[str, Figure]]``     |
+        |                 |                | keyed by mode, then feature.         |
+        |                 |                | Always contains exactly the keys     |
+        |                 |                | 'subgroup', 'equalized_odds',        |
+        |                 |                | 'gap' (in that order). Components    |
+        |                 |                | with no data return ``{}``.          |
+        +-----------------+----------------+--------------------------------------+
+
+        Returned dict for ``mode="all"`` (regardless of ``multi_feature``)
+        ALWAYS contains exactly three keys in order: ``'subgroup'`` ->
+        ``'equalized_odds'`` -> ``'gap'``. Within each multi-feature dict,
+        feature order follows ``sorted(feature_names)`` for determinism.
+
+        Note: ``mode="all"`` returns a structured dict and does NOT display
+        figures unless ``show=True``.
 
         Parameters
         ----------
         mode : str, optional
-            Visualization mode. One of {"summary", "all", "subgroup", "equalized_odds", "gap"}.
-            Default "summary".
+            Visualization mode. One of {"summary", "all", "subgroup",
+            "equalized_odds", "gap"}. Default "summary".
         show : bool
             Whether to display the figure interactively. Default True.
         save_path : str, optional
-            If provided, saves the figure(s) to this path.
-            - Single modes: Treated as full file path. Defaults to .png if extension missing.
-            - mode="all": Treated as base name. Appends suffixes and .png.
+            If provided, saves the figure(s) to this path. Only honored when
+            ``multi_feature=False`` (single-feature behavior).
+            - Single modes: Treated as full file path. Defaults to ``.png`` if
+              extension missing.
+            - ``mode="all"``: Treated as base name. Appends suffixes and ``.png``.
+            When ``multi_feature=True``, ``save_path`` is ignored (per-feature
+            saving is intentionally not exposed here; use the lower-level
+            ``plot_*_multi`` helpers if you need on-disk output).
+        multi_feature : bool, optional
+            If True, return per-feature figures rather than only the first
+            sensitive feature. Default False (backward compatible).
 
         Returns
         -------
-        matplotlib.figure.Figure | dict[str, matplotlib.figure.Figure | None]
+        matplotlib.figure.Figure
+            | dict[str, matplotlib.figure.Figure | None]
+            | dict[str, matplotlib.figure.Figure]
+            | dict[str, dict[str, matplotlib.figure.Figure]]
+            See the return-shape table above.
 
         Notes
         -----
-        Currently supports one sensitive feature per plot. If multiple are present,
-        the first is used. New modes can be added by extending ALLOWED_MODES and
-        dispatch logic without breaking existing behavior.
-        Function behavior MUST be deterministic given identical inputs (no randomness,
-        no state mutation). This includes consistent plot ordering, consistent key
-        ordering in dict, and no randomness in visualization.
-        Each returned Figure must be independent (no shared axes, state, or references
-        between plots). Each plot must be independently renderable and savable.
+        New modes can be added by extending ``ALLOWED_MODES`` and dispatch
+        logic without breaking existing behavior.
+        Function behavior MUST be deterministic given identical inputs (no
+        randomness, no state mutation). This includes consistent plot ordering,
+        consistent key ordering in dicts, and no randomness in visualization.
+        Each returned Figure must be independent (no shared axes, state, or
+        references between plots). Each plot must be independently renderable
+        and savable.
 
-        Caution: Figures are returned open. If calling this method repeatedly in a
-        loop, ensure you call plt.close(fig) on the returned figures to avoid
-        memory accumulation.
+        Caution: Figures are returned open. If calling this method repeatedly
+        in a loop, ensure you call ``plt.close(fig)`` on the returned figures
+        to avoid memory accumulation.
 
         Raises
         ------
         ValueError
-            If "bias" is not present in self.results or if data is unusable.
+            If ``mode`` is invalid, ``"bias"`` is not present in
+            ``self.results``, or the data is unusable.
         """
         import matplotlib.pyplot as plt
 
         from trustlens.visualization import _plot_bias
         from trustlens.visualization.fairness import (
             plot_equalized_odds,
+            plot_equalized_odds_multi,
             plot_fairness_gap,
+            plot_fairness_gap_multi,
             plot_subgroup_performance,
+            plot_subgroup_performance_multi,
         )
 
         ALLOWED_MODES = {"summary", "all", "subgroup", "equalized_odds", "gap"}
@@ -919,12 +968,24 @@ class TrustReport:
         if not (has_subgroup or has_eo or has_imbalance):
             raise ValueError("Bias data is present but not usable for visualization.")
 
+        # Reserved meta keys that should never be treated as feature names.
+        _META_KEYS = ("status", "reason", "details")
+
         def _get_first(key):
             d = bias_data.get(key, {})
             for k, v in d.items():
-                if k not in ("status", "reason", "details"):
+                if k not in _META_KEYS:
                     return k, v
             return None, None
+
+        def _sorted_feature_dict(key):
+            """Return ``{feature: data}`` ordered by ``sorted(feature_names)``.
+
+            Drops reserved meta keys so wrapper functions iterate only over
+            real features.
+            """
+            d = bias_data.get(key, {})
+            return {fname: d[fname] for fname in sorted(k for k in d if k not in _META_KEYS)}
 
         def _get_save_path(base_path, suffix=None):
             if base_path is None:
@@ -940,6 +1001,84 @@ class TrustReport:
             if not ext:
                 ext = ".png"
             return f"{name}{ext}"
+
+        # ------------------------------------------------------------------
+        # multi_feature=True dispatch
+        #
+        # Implemented as a thin transformation layer over the same plotting
+        # primitives the single-feature path uses. The "summary" mode simply
+        # falls through to the existing single-figure path because a summary
+        # plot is feature-agnostic by design.
+        # ------------------------------------------------------------------
+        if multi_feature and mode != "summary":
+            if save_path is not None:
+                logger.warning(
+                    "save_path is ignored when multi_feature=True; "
+                    "use plot_*_multi helpers directly for per-feature files."
+                )
+
+            if mode == "subgroup":
+                feat_dict = _sorted_feature_dict("subgroup_performance")
+                if not feat_dict:
+                    raise ValueError("Missing 'subgroup_performance' data for 'subgroup' mode.")
+                return plot_subgroup_performance_multi(feat_dict, show=show)
+
+            if mode == "equalized_odds":
+                feat_dict = _sorted_feature_dict("equalized_odds")
+                if not feat_dict:
+                    raise ValueError("Missing 'equalized_odds' data for 'equalized_odds' mode.")
+                return plot_equalized_odds_multi(feat_dict, show=show)
+
+            if mode == "gap":
+                # Priority: subgroup_performance -> equalized_odds, mirroring
+                # the single-feature path. The gap plot internally uses the
+                # equalized-odds-shaped data, so we use whichever is present.
+                feat_dict = _sorted_feature_dict("subgroup_performance")
+                if not feat_dict:
+                    feat_dict = _sorted_feature_dict("equalized_odds")
+                if not feat_dict:
+                    raise ValueError(
+                        "Missing sufficient data for 'gap' mode "
+                        "(either subgroup_performance or equalized_odds)."
+                    )
+                return plot_fairness_gap_multi(feat_dict, show=show)
+
+            if mode == "all":
+                # Return shape is fixed: three keys, in this order, every
+                # call. Components with no data map to {} (never None).
+                multi_results: dict[str, dict[str, plt.Figure]] = {
+                    "subgroup": {},
+                    "equalized_odds": {},
+                    "gap": {},
+                }
+
+                sub_dict = _sorted_feature_dict("subgroup_performance")
+                eo_dict = _sorted_feature_dict("equalized_odds")
+
+                if sub_dict:
+                    multi_results["subgroup"] = plot_subgroup_performance_multi(
+                        sub_dict, show=False
+                    )
+
+                if eo_dict:
+                    multi_results["equalized_odds"] = plot_equalized_odds_multi(eo_dict, show=False)
+
+                # 'gap' uses the same priority rule as the single-feature
+                # path: subgroup_performance first, falling back to
+                # equalized_odds.
+                gap_dict = sub_dict if sub_dict else eo_dict
+                if gap_dict:
+                    multi_results["gap"] = plot_fairness_gap_multi(gap_dict, show=False)
+
+                if show:
+                    backend = plt.get_backend().lower()
+                    if "agg" not in backend:
+                        try:
+                            plt.show()
+                        except Exception:
+                            pass
+
+                return multi_results
 
         if mode == "summary":
             # "summary" mode requires data compatible with _plot_bias()


### PR DESCRIPTION
## Summary

Adds an opt-in `multi_feature: bool = False` parameter to `TrustReport.plot_bias()` so callers can retrieve per-feature visualizations through the public API instead of dropping down to the lower-level `plot_*_multi` helpers added in #56.

`mode` and `multi_feature` are independent dimensions; the return shape is fully determined by their combination, with no flattening and no `None` values in multi-feature outputs.

| `mode` | `multi_feature` | Return type |
| --- | --- | --- |
| single (`summary`, `subgroup`, `equalized_odds`, `gap`) | `False` (default) | `Figure` (current behavior, unchanged) |
| `summary` | `True` | `Figure` (passthrough — same as `False`) |
| `subgroup` / `equalized_odds` / `gap` | `True` | `dict[str, Figure]` keyed by feature |
| `all` | `False` (default) | `dict[str, Figure \| None]` (current behavior, unchanged) |
| `all` | `True` | `dict[str, dict[str, Figure]]` keyed by mode then feature |

## Related Issue

Closes #74.

Design was locked down with @Khanz9664 in the issue thread before implementation.

## Type of Change

Please check the type of change:
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 📝 Documentation update (changes to docs or examples)
- [ ] 🧹 Maintenance (refactoring, code cleanup, dependencies)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Changes Made

- [x] Added `multi_feature: bool = False` parameter to `TrustReport.plot_bias()` in `trustlens/report.py`. Implemented as a thin transformation layer over the existing `plot_subgroup_performance_multi`, `plot_equalized_odds_multi`, and `plot_fairness_gap_multi` helpers — no plotting logic is reimplemented.
- [x] `mode="all", multi_feature=True` always returns the three keys `subgroup → equalized_odds → gap` in that order. Components with no underlying data map to `{}` (empty dict), never `None`.
- [x] `summary + multi_feature=True` falls through to the existing single-figure path (no per-feature expansion for summary, as agreed).
- [x] Feature ordering uses `sorted(feature_names)` via a `_sorted_feature_dict()` helper, so output is deterministic regardless of insertion order.
- [x] `'gap'` keeps the same priority rule as the single-feature path (`subgroup_performance` first, falling back to `equalized_odds`).
- [x] When `multi_feature=True`, `save_path` is ignored with a `logger.warning`. Per-feature file saving is intentionally not exposed here; callers who need on-disk output can use the `plot_*_multi` helpers directly.
- [x] Updated docstring with the new return-shape table and parameter description.
- [x] Added `tests/test_plot_bias_multi_feature.py` (18 cases across 6 test classes).
- [x] Updated `CHANGELOG.md` under `[Unreleased] / Added`.

Default behavior (`multi_feature=False`) is strictly preserved — the `mode="all", multi_feature=False` branch is byte-for-byte unchanged.

## Testing

```
make test       → 237 passed (219 pre-existing + 18 new)
make lint       → All checks passed
pre-commit run  → all hooks passed (ruff, ruff-format, mypy)
```

`tests/test_plot_bias_multi_feature.py` covers:

- `TestReturnShapeMatrix` — all four `(mode, multi_feature)` cells of the return-shape table.
- `TestSummaryMultiFeaturePassthrough` — `summary + multi_feature=True` returns the same type as `multi_feature=False`.
- `TestPartialDataHandling` — only `subgroup_performance`, only `equalized_odds`, no `bias` module at all, `'gap'` fallback when `subgroup_performance` is absent, and an explicit assertion that no value at any level is `None`.
- `TestDeterministicOrdering` — mode key order, sorted feature order (using a fixture that inserts `gender` before `age` to make the sort observable), and stability across repeated calls.
- `TestInvalidModeWithMultiFeature` — `mode="bogus"` raises `ValueError` regardless of `multi_feature`.
- `TestBackwardCompatibility` — default call and explicit `multi_feature=False` produce identical types.

- [x] All unit tests pass locally.
- [x] Added new tests for the changes made.

## Pre-submit Checklist

Before submitting, please ensure you have:
- [x] Run `pre-commit run --all-files` and all hooks passed.
- [x] Verified that all tests pass (`make test`).
- [x] Updated the `CHANGELOG.md` if applicable.
- [ ] Verified that documentation has been updated for new features.

> Note on the docs checkbox: the user-facing docstring on `plot_bias()` is updated with the full `(mode, multi_feature)` return-shape table and parameter description. I did not touch `docs/metrics/bias.md` or `README.md` in this PR — happy to add a short usage example to either if you'd like it as part of this change.

## Notes for Reviewers

A few choices worth flagging for review:

1. **`save_path` behavior under `multi_feature=True`** — currently ignored with a `logger.warning`. The reasoning is that `plot_*_multi(save_dir=...)` already provides per-feature file saving with its own naming convention (`subgroup_performance_<feature>.png`, etc.), and overloading `plot_bias(save_path=...)` to multi would either need a new naming scheme or risk collisions. Happy to switch to raising `ValueError` instead if you'd prefer a stricter contract.

2. **Asymmetry between `multi_feature=False` and `multi_feature=True` for `mode="all"`** — the existing `multi_feature=False` path can return `None` values per the original contract; the new `multi_feature=True` path uses `{}` instead, per the spec we agreed on. The asymmetry is intentional (preserving backward compatibility), but I wanted to flag it explicitly so it's not surprising during review.

3. **`'gap'` priority rule** — mirrors the existing single-feature path (`subgroup_performance` first, then `equalized_odds`). If you'd rather have multi-feature `'gap'` always use `equalized_odds` when both are present (since `plot_fairness_gap()` is built on equalized-odds-shaped data), I'm happy to switch. I went with consistency between the two paths as the safer default.

### Out of scope (potential follow-ups)

- Combined subplot layout (per the alternatives discussion in the issue).
- Multi-figure support inside `plot_module()` itself — `_plot_bias()` currently returns a single figure and the dispatcher's contract is one figure per module. Lifting that would touch `plot_module()`'s shape and is better handled separately.
