### PR TITLE
docs: add implementation plans for XGBoost, Keras, and TensorFlow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,8 @@ Some modules (e.g., `explainability/`) are under active development and are **no
 
 → [**docs/EXPERIMENTAL.md**](docs/EXPERIMENTAL.md) — rules, promotion criteria, and what "experimental" means.
 
+Roadmaps for **XGBoost**, **Keras**, and **TensorFlow** integrations live in [section 10](#10-framework-integration-plans).
+
 ---
 
 ## Code of Conduct
@@ -105,6 +107,7 @@ As a contributor, you are expected to respect and follow our code of conduct to 
 7. [Writing Tests](#writing-tests)
 8. [Pull Request Guidelines](#pull-request-guidelines)
 9. [Reporting Issues](#reporting-issues)
+10. [Framework integration plans](#10-framework-integration-plans)
 
 ---
 
@@ -361,6 +364,20 @@ pytest -k "calibration"    # run matching tests
 pytest --cov=trustlens     # run with coverage
 ```
 
+### Framework-Specific Tests
+Some tests require optional dependencies. To run them locally, install the corresponding extra and use the pytest markers:
+
+```bash
+# Install the extra (example: xgboost)
+pip install -e ".[xgboost]"
+
+# Run only XGBoost tests
+pytest -m requires_xgboost
+
+# Run only TensorFlow tests
+pytest -m requires_tensorflow
+```
+
 ---
 
 ## 8. Pull Request Guidelines
@@ -387,6 +404,18 @@ Open an issue with:
 - **Expected vs. actual behaviour**
 
 We aim to respond within 48 hours. ⏱
+
+---
+
+## 10. Framework integration plans
+
+Use these when picking up or reviewing large integrations (optional backends, shared prediction resolver, CI). Each plan is **scoped to one library**:
+
+| Plan | Scope |
+|------|--------|
+| [docs/plans/IMPLEMENTATION_PLAN_XGBoost.md](docs/plans/IMPLEMENTATION_PLAN_XGBoost.md) | **XGBoost** — stable tabular path, `XGBClassifier`, resolver branch, optional extra, tests. |
+| [docs/plans/IMPLEMENTATION_PLAN_Keras.md](docs/plans/IMPLEMENTATION_PLAN_Keras.md) | **Keras** — `model.predict` semantics, shapes, `analyze_keras`, experimental API (see plan for `keras` vs `tf.keras` scope). |
+| [docs/plans/IMPLEMENTATION_PLAN_TensorFlow.md](docs/plans/IMPLEMENTATION_PLAN_TensorFlow.md) | **TensorFlow** — optional `tensorflow` extra, lazy imports, CI, SavedModel/runtime notes; cross-links Keras plan for Keras API details. |
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,42 +1,46 @@
 # TrustLens Roadmap
 
-> Last updated: April 2026
+> Last updated: May 2026
 > This roadmap reflects our current priorities. Community feedback shapes every phase.
 
 ---
 
 ## Current State (v0.3.0)
 
-- Stable ML evaluation pipeline (calibration, failure, bias, representation)
-- Experimental modules isolated (explainability, faithfulness)
-- Strong contributor infrastructure in place
+- ✅ Stable ML evaluation pipeline (calibration, failure, bias, representation)
+- ✅ Head-to-head model comparison API (`trustlens.compare`)
+- ✅ Decision-ready Trust Score with penalty reasoning
+- ✅ Multi-feature fairness and 2D embedding diagnostics
+- ✅ Professional contributor infrastructure and documentation
+
+---
 
 ## Status Legend
 
-- [x] Completed (production-ready, part of analyze pipeline)
-- [~] In progress / Experimental (not part of core `analyze()` pipeline)
+- [x] Completed (production-ready)
+- [~] In progress / Experimental (limited availability)
 - [ ] Planned
 
 ---
 
-## Active Work (Now)
+## Active Work (v0.3.x)
 
 These are high-priority items currently being developed or targeted for the next release.
 
-- [x] **Equalized Odds** (Issue #25)
-- [~] **UMAP/t-SNE Visualization** (Issue #22) — *[OPEN]*
+- [ ] **Policy Profiles** (Issue #56) — *Context-aware scoring (Strict/Lenient)*
+- [ ] **TrustComparison** (Issue #57) — *Differential reliability audits*
+- [ ] **XGBoost Support** — *Native prediction resolver for XGBClassifier*
+- [~] **Deep Learning Backends** — *Experimental Keras & TensorFlow integration*
 - [~] **HTML Report Export** (Issue #19) — *[OPEN]*
+- [ ] **Maximum Calibration Error (MCE)** (Issue #1)
 
 ---
 
 ## Phase 1: MVP — *The Foundation*
 
-**Target: v0.1.2**
+**Status: COMPLETE**
 
 The minimal set of features required to be genuinely useful to practitioners.
-
-Note: As of v0.3.0, TrustLens focuses on classical ML evaluation.
-Deep learning explainability features are under experimental development and not part of the core pipeline.
 
 ### Deliverables
 - [x] Core `analyze()` API with module dispatch
@@ -45,11 +49,11 @@ Deep learning explainability features are under experimental development and not
 - [x] **Failure Analysis**: misclassification summary, confidence gap histogram
 - [x] **Bias Detection**: class imbalance report, subgroup accuracy/F1
 - [x] **Representation Analysis**: silhouette separability, CKA metric
-- [~] **Explainability**: Grad-CAM with PyTorch support — *[ASSIGNED: Maintainer]*
-- [~] **Faithfulness**: pixel deletion + insertion tests (AUPC) — *[OPEN]*
+- [~] **Explainability**: Grad-CAM with PyTorch support — *[EXPERIMENTAL]*
+- [~] **Faithfulness**: pixel deletion + insertion tests (AUPC) — *[EXPERIMENTAL]*
 - [x] Plugin system (BasePlugin + PluginRegistry)
-- [x] Full test suite (>80% coverage)
-- [x] Professional README (with logo), CONTRIBUTING, quickstart examples
+- [x] Full test suite (>230 tests)
+- [x] Professional README, CONTRIBUTING, quickstart examples
 - [x] PyPI package & GitHub Actions CI (lint/test/format)
 
 ---
@@ -62,53 +66,52 @@ Deep learning explainability features are under experimental development and not
 
 ### High Priority
 - [x] **Equalized Odds** (Issue #25)
-- [~] **UMAP/t-SNE Visualization** (Issue #22) — [OPEN]
+- [x] **UMAP/t-SNE Visualization** (Issue #22)
+- [x] **Jupyter Rich Display** (`_repr_html_`) (Issue #24)
+- [x] **Progress Bars** via `tqdm` (Issue #28)
+- [x] **Subgroup ECE** (calibration per demographic group)
 - [~] **HTML Report Export** (Issue #19) — [OPEN]
-- [ ] **Maximum Calibration Error (MCE)** (Issue #1)
 - [ ] **Temperature Scaling** (Issue #18)
-- [ ] **Jupyter Rich Display** (`_repr_html_`) (Issue #24)
+- [ ] **Maximum Calibration Error (MCE)** (Issue #1)
 
 ### Nice to Have
 - [ ] **Multi-class ECE** (label-wise decomposition)
-- [ ] **Subgroup ECE** (calibration per demographic group)
 - [ ] **Critical Failures** table for `TrustReport`
 - [ ] **Per-class PR curves** and optimal threshold analysis
 - [ ] **Prediction Flip Analysis** (robustness check)
 - [ ] **Eigen-CAM** (gradient-free explainability)
 - [ ] **Integrated Gradients (IG)** for tabular models
 - [ ] **SHAP Wrapper** (optional dependency)
-- [ ] **Intrinsic Dimensionality** estimation for embeddings
-- [ ] **Linear Probing** accuracy per layer
-- [ ] **Progress Bars** via `tqdm` (Issue #28)
 - [ ] **Text-based Sensitive Feature Parsing**
+- [ ] **Linear Probing** accuracy per layer
+- [ ] **Intrinsic Dimensionality** estimation for embeddings
+
+### Framework Support
+- [ ] **XGBoost Integration** — Native `analyze()` support for `XGBClassifier`
+- [~] **Keras Experimental** — Sequential and functional model support
+- [~] **TensorFlow Experimental** — SavedModel loading and lazy import hygiene
 
 ---
 
-## Phase 3: Research Features — *Frontier Methods*
+## Phase 3: Comparative & Research — *Frontier Methods*
 
-**Target: v0.3.0**
+**Target: v0.3.x / v0.4.0**
 
-Methods primarily of interest to ML researchers pushing state-of-the-art.
+Methods primarily of interest to ML researchers pushing state-of-the-art and production diffing.
 
-### Vision Transformers (ViTs)
-- [ ] Generic attention rollout for ViT models
-- [ ] DINO-compatible self-attention map visualization
-- [ ] ViT Grad-CAM via register_hook on attention weights
-
-### NLP & Sequence Models
-- [ ] Attention-based saliency for BERT-style models
-- [ ] Token-level faithfulness via masking tests
-- [ ] Semantic similarity–based explanation consistency
+### Comparative Audits
+- [x] **Model recommendation engine** (`trustlens.compare`)
+- [x] **Score comparison tables**
+- [ ] **Policy-aware deltas** (Issue #57)
 
 ### Advanced Representation
-- [ ] Representation fragility score (adversarial perturbation in embedding space)
-- [ ] Neuron activation statistics per class
 - [ ] Layer-wise CKA heatmap (n_layers × n_layers)
+- [ ] Neuron activation statistics per class
+- [ ] Representation fragility score (adversarial perturbation)
 
 ### Benchmarking
 - [ ] `benchmark()` function — run TrustLens on standard datasets (CIFAR-10, etc.)
 - [ ] Baseline scores for common architectures
-- [ ] Score comparison tables
 
 ---
 
@@ -118,21 +121,18 @@ Methods primarily of interest to ML researchers pushing state-of-the-art.
 
 Making TrustLens a community standard.
 
-### Contribution Infrastructure
-- [ ] Contributor hall of fame in README
+### Contribution & Documentation
+- [x] Contributor hall of fame in README
+- [x] Video walkthrough series
+- [x] Interactive Jupyter notebooks (Colab-ready)
 - [ ] Plugin submission process (community plugin registry)
 - [ ] `trustlens-contrib` companion repository
 
 ### Integrations
-- [ ] **Hugging Face**: `evaluate`-compatible metric modules
 - [ ] **MLflow**: log TrustLens metrics as experiment artifacts
 - [ ] **Weights & Biases**: log reliability diagrams as charts
+- [ ] **Hugging Face**: `evaluate`-compatible metric modules
 - [ ] **DVC**: TrustLens report as a DVC stage output
-
-### Documentation
-- [ ] Full Read the Docs site with API reference
-- [ ] Interactive Jupyter notebooks (Binder/Colab)
-- [ ] Video walkthrough series
 
 ---
 
@@ -146,11 +146,6 @@ TrustLens as a complete model analysis platform.
 - [ ] Zero-config web UI (`trustlens serve`) using FastAPI + React
 - [ ] Interactive reliability diagrams (Plotly)
 - [ ] Model comparison views
-
-### Leaderboard
-- [ ] Public leaderboard for model calibration benchmarks
-- [ ] Dataset-specific calibration baselines
-- [ ] Community-submitted benchmark results
 
 ### Enterprise Features
 - [ ] Scheduled monitoring reports (model drift detection)

--- a/docs/plans/IMPLEMENTATION_PLAN_Keras.md
+++ b/docs/plans/IMPLEMENTATION_PLAN_Keras.md
@@ -1,0 +1,175 @@
+# Implementation plan: Keras
+
+This document is for **contributors** and **maintainers** integrating the **Keras API** (`keras.Model`, `Sequential`, `predict`) with TrustLens so classification models produce NumPy `y_pred` and `y_prob` for the existing analysis pipeline.
+
+**Related plans:** [XGBoost](IMPLEMENTATION_PLAN_XGBoost.md) (tabular backend) · [TensorFlow](IMPLEMENTATION_PLAN_TensorFlow.md) (TensorFlow package, `tf.keras`, SavedModel, CI)
+
+**Status target:** **Experimental** until [`EXPERIMENTAL.md`](../EXPERIMENTAL.md) promotion criteria are met. Do **not** require Keras (or TensorFlow) for `pip install trustlens`.
+
+---
+
+## Scope: “Keras” vs “TensorFlow” in this repo
+
+| Topic | This document (Keras) | [TensorFlow plan](IMPLEMENTATION_PLAN_TensorFlow.md) |
+|--------|-------------------------|------------------------------------------------------|
+| `model.predict` output shapes, binary vs multiclass | **Primary** | References this plan |
+| `keras` PyPI package, `keras.Model` type checks | **Primary** | N/A |
+| `tensorflow` PyPI extra, lazy `import tensorflow` | Cross-reference | **Primary** |
+| `tf.keras` as deployment vehicle | Note: same API patterns | **Primary** for import/version/CI |
+| SavedModel, serving, GPU runtime | Out of scope (v1) | **Primary** |
+
+Many users only use **`tf.keras`**. Implementation may ship **`analyze_keras`** in `trustlens.experimental.keras` using `tf.keras.Model` first; this Keras plan still defines **API semantics** and tests that apply to any Keras-compatible `predict` output.
+
+---
+
+## Executive summary
+
+| Item | Decision |
+|------|----------|
+| **Goal** | Resolve `y_pred`, `y_prob` from a trained **classification** Keras model and run `_run_analysis_pipeline(...)` (shared with `analyze()`). |
+| **Public API (until promotion)** | e.g. `from trustlens.experimental.keras import analyze_keras` — avoid silent heavy imports from `import trustlens`. |
+| **Dependencies** | Optional extra, e.g. `keras = ["keras>=3"]` **and/or** overlap with TensorFlow extra when implementation uses `tf.keras` — document the **single supported install path for v1** in `pyproject.toml` and here once chosen. |
+| **Import rule** | Lazy `import keras` or lazy `import tensorflow as tf` **only** inside experimental modules (see TensorFlow plan for TF-specific hygiene). |
+
+---
+
+## Prerequisites
+
+1. **`_run_analysis_pipeline`** extracted from `trustlens.api.analyze()` so Keras code does not duplicate calibration / failure / bias / representation logic. See [XGBoost plan](IMPLEMENTATION_PLAN_XGBoost.md) PR A for resolver context; pipeline extraction can land in the same or adjacent PR.
+2. Optional **`y_pred=`** / **`y_prob=`** on `analyze()` for power users who bypass Keras resolution.
+
+---
+
+## Objectives (Keras)
+
+1. **Binary classification**  
+   - Sigmoid output `(n, 1)`: normalize to TrustLens binary convention (two-column `y_prob` or documented single-column path consistent with `api.py`).  
+   - Softmax output `(n, 2)`: use as-is; `y_pred = argmax(axis=1)`.
+
+2. **Multiclass**  
+   Softmax `(n, C)`, `C > 2`: `y_prob` as-is; `y_pred = argmax(axis=1)`.
+
+3. **Input**  
+   **v1:** NumPy `X` (and optional `embeddings`) only; call `model.predict(X, verbose=0)` then `np.asarray(..., dtype=np.float64)`.
+
+4. **Examples**  
+   `examples/keras_audit.py`: small `Sequential` model on synthetic data, `analyze_keras`, optional `report.save(...)`.
+
+5. **Documentation**  
+   `docs/EXPERIMENTAL.md`: Keras subsection — install, API, limitations, promotion checklist.
+
+---
+
+## Non-goals (v1)
+
+- Multi-label, regression, object detection, dict / ragged inputs.
+- Custom training loops, callbacks, or layer freezing logic.
+- **Native** multi-backend Keras 3 on JAX/Torch for CI unless maintainers explicitly add jobs (numpy/TF path is acceptable for v1).
+- Monkey-patching `predict_proba` onto Keras models.
+
+---
+
+## Technical design
+
+### 1. Output shape matrix (canonical)
+
+| Head | `predict` shape | `y_prob` (TrustLens) | `y_pred` |
+|------|-----------------|----------------------|----------|
+| Binary sigmoid | `(n, 1)` | `[1-p, p]` shape `(n, 2)` *recommended* | `argmax` or `(p > 0.5).astype(int)` — **pick one and test** |
+| Binary softmax | `(n, 2)` | unchanged | `argmax(axis=1)` |
+| Multiclass softmax | `(n, C)` | unchanged | `argmax(axis=1)` |
+
+Centralize normalization in **`resolve_keras_predictions(model, X) -> tuple[y_pred, y_prob]`** in `trustlens/experimental/keras.py` (or submodule).
+
+### 2. Model typing
+
+- Prefer **`isinstance(model, keras.Model)`** when using the standalone `keras` package.
+- If v1 targets **`tf.keras.Model`** only, state that explicitly in module docstring and still follow the shape matrix above (types live in TensorFlow plan).
+
+### 3. Integration
+
+```text
+analyze_keras(model, X, y_true, *, embeddings=None, ...) 
+  -> resolve_keras_predictions(model, X)
+  -> _run_analysis_pipeline(y_true, y_pred, y_prob, ...)
+  -> TrustReport
+```
+
+### 4. Embeddings
+
+Same as sklearn path: user-supplied `embeddings` NumPy array. Optional later: helper to attach a Keras intermediate layer (separate feature / not v1).
+
+---
+
+## Files to add or change (checklist)
+
+| Path | Action |
+|------|--------|
+| `trustlens/experimental/keras.py` | `resolve_keras_predictions`, `analyze_keras`. |
+| `trustlens/experimental/__init__.py` | Docstring / limited exports; no heavy imports at import time. |
+| `trustlens/api.py` | Export `_run_analysis_pipeline` for experimental use **or** move pipeline to `trustlens/backends/pipeline.py` to avoid circular imports. |
+| `pyproject.toml` | Optional `keras` and/or document use of `tensorflow` extra — one clear story. |
+| `docs/EXPERIMENTAL.md` | Keras integration subsection. |
+| `docs/getting_started.md` | One-line pointer to experimental Keras. |
+| `examples/keras_audit.py` | End-to-end demo. |
+| `tests/test_keras_experimental.py` | Shape unit tests (pure NumPy) + optional integration tests. |
+| `pyproject.toml` markers | e.g. `requires_keras` / reuse `requires_tensorflow` if tests use tf.keras only. |
+
+---
+
+## Testing strategy
+
+1. **Pure NumPy tests** — Feed `resolve_keras_predictions`–level helpers with fixed arrays mimicking `(n,1)`, `(n,2)`, `(n,C)` outputs; run in default CI without Keras installed.
+2. **Integration tests** — Behind `pytest.importorskip("keras")` or `tensorflow` depending on v1 choice; binary + 3-class models.
+3. **Import hygiene** — `import trustlens` must not import `keras` or `tensorflow` (subprocess test recommended).
+
+---
+
+## CI recommendations
+
+- Default PR CI: **no** heavy Keras/TF install unless job time is acceptable.
+- Optional: weekly / `workflow_dispatch` job installing the chosen extra and running marked tests.
+
+Coordinate exact markers with [TensorFlow plan](IMPLEMENTATION_PLAN_TensorFlow.md) to avoid duplicate jobs.
+
+---
+
+## Acceptance criteria (Keras experimental “ready”)
+
+- [ ] `analyze_keras` returns `TrustReport` with calibration, failure, bias, representation populated for binary and 3-class toy models.
+- [ ] Binary sigmoid and softmax paths both tested.
+- [ ] `import trustlens` does not load Keras/TF (per implementation choice).
+- [ ] `docs/EXPERIMENTAL.md` updated.
+- [ ] `CHANGELOG.md` entry (Experimental).
+
+---
+
+## Suggested PR breakdown
+
+1. **Pipeline extraction** — `_run_analysis_pipeline` only; no Keras.
+2. **Experimental Keras** — `resolve_keras_predictions` + `analyze_keras` + tests + example + docs.
+
+---
+
+## Promotion to stable API
+
+When promoted per `EXPERIMENTAL.md`:
+
+- Document `framework="keras"` on main `analyze()` **or** keep `analyze_keras` as the supported entry point.
+- Expand CI if Keras becomes a first-class optional extra.
+
+---
+
+## FAQ
+
+**Q: Keras 3 multi-backend vs tf.keras only?**  
+**A:** v1 should pick **one** supported install to reduce support burden; document the other as “community tested” or future work.
+
+**Q: Overlap with TensorFlow plan?**  
+**A:** Keras plan owns **shapes and API**; TensorFlow plan owns **TF package**, versions, SavedModel, and lazy-import policy.
+
+---
+
+## Document history
+
+- **Scope:** Keras API only; XGBoost and TensorFlow have separate plans.

--- a/docs/plans/IMPLEMENTATION_PLAN_Keras.md
+++ b/docs/plans/IMPLEMENTATION_PLAN_Keras.md
@@ -42,20 +42,20 @@ Many users only use **`tf.keras`**. Implementation may ship **`analyze_keras`** 
 
 ## Objectives (Keras)
 
-1. **Binary classification**  
-   - Sigmoid output `(n, 1)`: normalize to TrustLens binary convention (two-column `y_prob` or documented single-column path consistent with `api.py`).  
+1. **Binary classification**
+   - Sigmoid output `(n, 1)`: normalize to TrustLens binary convention (two-column `y_prob` or documented single-column path consistent with `api.py`).
    - Softmax output `(n, 2)`: use as-is; `y_pred = argmax(axis=1)`.
 
-2. **Multiclass**  
+2. **Multiclass**
    Softmax `(n, C)`, `C > 2`: `y_prob` as-is; `y_pred = argmax(axis=1)`.
 
-3. **Input**  
+3. **Input**
    **v1:** NumPy `X` (and optional `embeddings`) only; call `model.predict(X, verbose=0)` then `np.asarray(..., dtype=np.float64)`.
 
-4. **Examples**  
+4. **Examples**
    `examples/keras_audit.py`: small `Sequential` model on synthetic data, `analyze_keras`, optional `report.save(...)`.
 
-5. **Documentation**  
+5. **Documentation**
    `docs/EXPERIMENTAL.md`: Keras subsection — install, API, limitations, promotion checklist.
 
 ---
@@ -89,7 +89,7 @@ Centralize normalization in **`resolve_keras_predictions(model, X) -> tuple[y_pr
 ### 3. Integration
 
 ```text
-analyze_keras(model, X, y_true, *, embeddings=None, ...) 
+analyze_keras(model, X, y_true, *, embeddings=None, ...)
   -> resolve_keras_predictions(model, X)
   -> _run_analysis_pipeline(y_true, y_pred, y_prob, ...)
   -> TrustReport
@@ -162,10 +162,10 @@ When promoted per `EXPERIMENTAL.md`:
 
 ## FAQ
 
-**Q: Keras 3 multi-backend vs tf.keras only?**  
+**Q: Keras 3 multi-backend vs tf.keras only?**
 **A:** v1 should pick **one** supported install to reduce support burden; document the other as “community tested” or future work.
 
-**Q: Overlap with TensorFlow plan?**  
+**Q: Overlap with TensorFlow plan?**
 **A:** Keras plan owns **shapes and API**; TensorFlow plan owns **TF package**, versions, SavedModel, and lazy-import policy.
 
 ---

--- a/docs/plans/IMPLEMENTATION_PLAN_TensorFlow.md
+++ b/docs/plans/IMPLEMENTATION_PLAN_TensorFlow.md
@@ -142,10 +142,10 @@ No module-level `tensorflow` import in files that are transitively imported by `
 
 ## FAQ
 
-**Q: Why a separate doc from Keras?**  
+**Q: Why a separate doc from Keras?**
 **A:** TensorFlow covers **package install, import policy, CI, SavedModel, runtime**; Keras covers **model.predict contract** for Keras API models (including `tf.keras`).
 
-**Q: JAX?**  
+**Q: JAX?**
 **A:** Out of scope for this TensorFlow plan.
 
 ---

--- a/docs/plans/IMPLEMENTATION_PLAN_TensorFlow.md
+++ b/docs/plans/IMPLEMENTATION_PLAN_TensorFlow.md
@@ -1,0 +1,155 @@
+# Implementation plan: TensorFlow
+
+This document is for **contributors** and **maintainers** integrating the **TensorFlow** Python package (`tensorflow`) with TrustLens: dependency management, **lazy imports**, CI, and TensorFlow-specific loading paths. It does **not** replace the [Keras plan](IMPLEMENTATION_PLAN_Keras.md), which owns **`model.predict` semantics** and shape normalization for Keras-style models.
+
+**Related plans:** [XGBoost](IMPLEMENTATION_PLAN_XGBoost.md) · [Keras](IMPLEMENTATION_PLAN_Keras.md)
+
+**Status target:** **Experimental** for any code path that executes `import tensorflow` during a typical `import trustlens`. Follow [`EXPERIMENTAL.md`](../EXPERIMENTAL.md) until promotion.
+
+---
+
+## Executive summary
+
+| Item | Decision |
+|------|----------|
+| **Goal** | Allow TrustLens to run against models and artifacts in the TensorFlow ecosystem **without** adding TensorFlow to core dependencies or to the import chain of `import trustlens`. |
+| **Primary surfaces (v1)** | Optional `pip install trustlens[tensorflow]` (or equivalent extra name); experimental modules that call `import tensorflow as tf` **inside functions**. |
+| **Keras API** | Most users use **`tf.keras`**. Prediction shape rules and `analyze_keras` behavior are specified in [IMPLEMENTATION_PLAN_Keras.md](IMPLEMENTATION_PLAN_Keras.md); this document covers TF packaging, versions, SavedModel, and CI. |
+
+---
+
+## Prerequisites
+
+1. **Shared resolver / pipeline** — Same as [XGBoost plan](IMPLEMENTATION_PLAN_XGBoost.md): internal prediction resolution and `_run_analysis_pipeline` extracted from `analyze()` so TensorFlow integration does not fork metric code.
+2. **Keras semantics** — Implementers should read [Keras plan](IMPLEMENTATION_PLAN_Keras.md) before merging TF-specific PRs that call `model.predict`.
+
+---
+
+## Objectives (TensorFlow)
+
+1. **Optional dependency** — `pyproject.toml` includes e.g. `tensorflow = ["tensorflow>=X.Y"]` with a conservative **minimum** version; revisited when security advisories apply (align with existing `pip-audit` CI).
+
+2. **Lazy import discipline** — No `import tensorflow` at top level in `trustlens/__init__.py`, `trustlens/api.py`, or any module imported by default trustlens entry points.
+
+3. **Experimental entry points** — Code that needs TF lives under e.g. `trustlens/experimental/` (or clearly named submodule) and is not re-exported from `trustlens.__init__` in v1.
+
+4. **CI policy** — Document whether PR CI installs TensorFlow (usually **no** due to size) and whether **weekly / manual** workflows run TF tests.
+
+5. **Version metadata** — When saving reports from TF-backed runs, optional `tensorflow_version` field in metadata JSON.
+
+---
+
+## Non-goals (v1)
+
+- TPU / `MirroredStrategy` / multi-worker training integration.
+- TensorFlow Extended (TFX) pipelines.
+- Full **SavedModel** serving parity (may be v2; see below for optional stretch).
+
+---
+
+## Technical design
+
+### 1. Lazy import pattern
+
+```python
+def _require_tf():
+    import tensorflow as tf
+    return tf
+
+def some_entry(...):
+    tf = _require_tf()
+    ...
+```
+
+No module-level `tensorflow` import in files that are transitively imported by `from trustlens import analyze`.
+
+### 2. `tf.keras` as the default supported model class
+
+- Type checks: `isinstance(model, tf.keras.Model)` after lazy import.
+- For prediction output shapes, follow [Keras plan](IMPLEMENTATION_PLAN_Keras.md).
+
+### 3. SavedModel (optional stretch / v2)
+
+- Document `loaded = tf.saved_model.load(path)` and how (if) a concrete function maps to `(y_pred, y_prob)` for TrustLens.
+- If v1 does not support SavedModel, state **explicitly** in `EXPERIMENTAL.md` to avoid user confusion.
+
+### 4. Tensors vs NumPy
+
+- **v1:** Convert model outputs to NumPy at the boundary before metrics (consistent with rest of TrustLens).
+- Document memory implications for large validation sets.
+
+### 5. GPU / CPU in CI
+
+- Prefer **CPU-only** TensorFlow wheels in CI to reduce flakiness unless maintainers provision GPU runners.
+
+---
+
+## Files to add or change (checklist)
+
+| Path | Action |
+|------|--------|
+| `pyproject.toml` | Optional `[tensorflow]` extra; version lower bound. |
+| `trustlens/experimental/*.py` | Any TF-specific helpers; lazy imports only. |
+| `.github/workflows/ci.yml` | Optional scheduled / `workflow_dispatch` job: `pip install -e ".[dev,tensorflow]"` + `pytest -m requires_tensorflow`. |
+| `docs/EXPERIMENTAL.md` | TensorFlow subsection: install, lazy import guarantee, CI, limitations. |
+| `CONTRIBUTING.md` | How to run TF-marked tests locally. |
+| `tests/test_tensorflow_import_hygiene.py` | Subprocess: `import trustlens` → assert `'tensorflow' not in sys.modules`. |
+| `CHANGELOG.md` | Experimental TF support entry. |
+
+---
+
+## Testing strategy
+
+1. **Import hygiene tests** — Always run in default CI; no TensorFlow install required.
+2. **Marked integration tests** — `@pytest.mark.requires_tensorflow` or `pytest.importorskip("tensorflow")`; run in optional job.
+3. **Version matrix** — At most **one** TF version + **one** Python version in optional CI unless the team expands capacity.
+
+---
+
+## Acceptance criteria (TensorFlow track “ready”)
+
+- [ ] Optional extra documented; core install unchanged.
+- [ ] `import trustlens` does not import TensorFlow (automated test).
+- [ ] Optional CI job **or** documented maintainer-only local run for TF tests.
+- [ ] `docs/EXPERIMENTAL.md` describes scope and points to Keras plan for `predict` shapes.
+- [ ] `CHANGELOG.md` updated.
+
+---
+
+## Suggested PR breakdown
+
+1. **Extras + import hygiene tests only** — No functional TF analysis yet; proves packaging.
+2. **Experimental TF-backed analyze path** — Wires lazy TF import to `analyze_keras` or equivalent implemented per Keras plan.
+
+---
+
+## Security and maintenance
+
+- Pin minimum TensorFlow versions; monitor CVEs (project already runs `pip-audit`).
+- Do not execute arbitrary user graphs without documentation of trust boundaries.
+
+---
+
+## Maintainer sign-off
+
+| Gate | ☐ |
+|------|---|
+| Optional extra / no core bloat | ☐ |
+| Lazy import verified | ☐ |
+| CI / docs / changelog | ☐ |
+
+---
+
+## FAQ
+
+**Q: Why a separate doc from Keras?**  
+**A:** TensorFlow covers **package install, import policy, CI, SavedModel, runtime**; Keras covers **model.predict contract** for Keras API models (including `tf.keras`).
+
+**Q: JAX?**  
+**A:** Out of scope for this TensorFlow plan.
+
+---
+
+## Document history
+
+- **Scope:** TensorFlow package only; Keras API semantics live in `IMPLEMENTATION_PLAN_Keras.md`.

--- a/docs/plans/IMPLEMENTATION_PLAN_XGBoost.md
+++ b/docs/plans/IMPLEMENTATION_PLAN_XGBoost.md
@@ -1,0 +1,150 @@
+# Implementation plan: XGBoost
+
+This document is for **contributors** and **maintainers** adding **first-class XGBoost** support to TrustLens. It covers **only** the XGBoost library and its interaction with the existing `analyze()` pipeline.
+
+**Related plans (other libraries):** [Keras](IMPLEMENTATION_PLAN_Keras.md) · [TensorFlow](IMPLEMENTATION_PLAN_TensorFlow.md)
+
+**Status target:** **Stable** — same public `analyze()` entry point as scikit-learn–compatible estimators, optional install extra, no `xgboost` import when users run `import trustlens`.
+
+---
+
+## Executive summary
+
+| Item | Decision |
+|------|----------|
+| **Goal** | Users with `xgboost.XGBClassifier` call `analyze(model, X, y_true, ...)` without manually passing `y_prob` when `predict_proba` is available. |
+| **Where it lives** | `trustlens.backends.predictions` (resolver branch) + `trustlens.api.analyze()`; optional `framework="xgboost"` or lazy `isinstance` after `import xgboost`. |
+| **Dependencies** | Optional extra: `pip install trustlens[xgboost]` with `xgboost>=…` lower bound aligned with NumPy / scikit-learn. |
+| **Import rule** | **Lazy** `import xgboost` only inside the resolver branch; never at package top level. |
+
+TrustLens metrics already consume NumPy `y_true`, `y_pred`, `y_prob`. XGBoost work is **boundary normalization** only.
+
+---
+
+## Prerequisites (shared with other backends)
+
+Before XGBoost-specific PRs, the codebase should have (or gain in **PR A**):
+
+1. **Internal resolver** — `trustlens/backends/predictions.py` (or equivalent) with a function such as `resolve_predictions(model, X, y_prob=None, y_pred=None, framework=None) -> tuple[np.ndarray, np.ndarray]`.
+2. **Sklearn path unchanged** — Current `analyze()` behavior remains the default; regression tests in `tests/test_api.py` stay green.
+3. **Optional `y_pred=`** on `analyze()` — Recommended so users can bypass resolver edge cases without waiting for a fix.
+
+Cross-team note: the same resolver hosts Keras and TensorFlow branches documented in their respective plans; merge order is maintainer choice, but **PR A (resolver + sklearn only)** should not require XGBoost installed.
+
+---
+
+## Objectives (XGBoost)
+
+1. **Binary classification** — `XGBClassifier` with `objective` implying probabilities; `predict_proba` / `predict` return shapes compatible with `trustlens.api` binary calibration (`y_prob[:, 1]` when two columns).
+2. **Multiclass** — `predict_proba` shape `(n_samples, n_classes)`; no crashes in calibration / failure / bias modules.
+3. **Documentation** — `docs/getting_started.md` and `docs/api_reference.md`: minimal example with `XGBClassifier` + `analyze()`.
+4. **Discoverability** — Optional extra documented in README / PyPI classifiers if appropriate.
+
+---
+
+## Non-goals (v1)
+
+- `XGBRegressor` or non-classification tasks (unless calibration semantics are extended project-wide).
+- Raw `xgboost.Booster` + `DMatrix` without an sklearn-style wrapper (document workaround: wrap or pass `y_prob` / `y_pred` manually).
+- GPU-only CI as a merge blocker.
+- XGBoost **training** utilities inside TrustLens (users train outside; TrustLens analyzes).
+
+---
+
+## Technical design
+
+### 1. Detection
+
+Pick **one** primary strategy and document it:
+
+- **Explicit:** `analyze(..., framework="xgboost")` forces the XGBoost branch.
+- **Implicit:** After lazy `import xgboost`, `isinstance(model, xgboost.XGBClassifier)`.
+
+Avoid duck-typing that could mis-classify other estimators.
+
+### 2. Prediction path
+
+```text
+y_prob = np.asarray(model.predict_proba(X), dtype=np.float64)
+y_pred = np.asarray(model.predict(X))
+```
+
+**Binary edge case:** If `predict_proba` ever returns shape `(n_samples,)`, reshape to `(n_samples, 2)` using `[1 - p, p]` or match the convention already used in `trustlens/api.py` for positive-class scores. Add a unit test that mirrors XGBoost’s actual output for a toy fixture.
+
+### 3. Sparse features
+
+If `X` is `scipy.sparse` and XGBoost accepts it, either document “dense NumPy only for v1” or thread sparse through **only** where `analyze()` already allows it; do not silently densify huge matrices without documentation.
+
+### 4. Metadata (optional v1)
+
+Record in saved report metadata, e.g. `framework: xgboost`, `xgboost_version`, booster params summary string — helpful for audits.
+
+---
+
+## Files to add or change (checklist)
+
+| Path | Action |
+|------|--------|
+| `pyproject.toml` | `[project.optional-dependencies]` → `xgboost = ["xgboost>=…"]`. |
+| `trustlens/backends/predictions.py` | `_predict_xgboost(...)` or branch inside `resolve_predictions`. |
+| `trustlens/api.py` | Call resolver from `analyze()`; optional `framework` / `y_pred` kwargs. |
+| `docs/getting_started.md` | Short XGBoost example. |
+| `docs/api_reference.md` | `framework`, shapes, manual overrides. |
+| `tests/test_predictions_resolver.py` | Mocks + shape normalization without `xgboost` installed. |
+| `tests/test_api_xgboost.py` | `pytest.importorskip("xgboost")` or `@pytest.mark.requires_xgboost`. |
+| `CHANGELOG.md` | `feat:` entry. |
+
+---
+
+## Testing strategy
+
+- **Default CI:** Either skip XGBoost tests when extra not installed, or add a **single** optional job (Linux, one Python) `pip install -e ".[dev,xgboost]"` and run marked tests — pick one and document in `CONTRIBUTING.md`.
+- **Markers:** Register `requires_xgboost` in `[tool.pytest.ini_options]` markers.
+- **Import smoke:** Subprocess or `sys.modules` assertion: `import trustlens` does not load `xgboost`.
+
+---
+
+## Acceptance criteria (XGBoost complete)
+
+- [ ] `analyze(xgb_clf, X_val, y_val, verbose=False)` works on a binary `make_classification` fixture without `y_prob`.
+- [ ] Three-class fixture completes without error.
+- [ ] No `xgboost` import at `import trustlens` time.
+- [ ] Ruff + mypy clean for new code.
+- [ ] Docs and changelog updated.
+
+---
+
+## Suggested PR breakdown
+
+1. **PR A — Resolver + sklearn parity**  
+   Introduce `resolve_predictions`; wire `analyze()`; no XGBoost yet; tests prove identical behavior to today.
+
+2. **PR B — XGBoost**  
+   Optional extra, branch, tests, docs — isolated revert surface.
+
+---
+
+## Maintainer sign-off
+
+| Gate | ☐ |
+|------|---|
+| API / docs reviewed | ☐ |
+| Tests (default + optional) | ☐ |
+| No optional dep on core import | ☐ |
+| CHANGELOG entry | ☐ |
+
+---
+
+## FAQ
+
+**Q: LightGBM / CatBoost?**  
+**A:** Often work today via `predict` / `predict_proba`. Add library-specific tests in follow-up PRs; open a dedicated plan only if a quirk requires a new branch.
+
+**Q: Order relative to Keras / TensorFlow?**  
+**A:** Independent once PR A exists. XGBoost is lighter and is a good first optional backend.
+
+---
+
+## Document history
+
+- **Scope:** XGBoost only; Keras and TensorFlow have separate plans in this directory.

--- a/docs/plans/IMPLEMENTATION_PLAN_XGBoost.md
+++ b/docs/plans/IMPLEMENTATION_PLAN_XGBoost.md
@@ -116,10 +116,10 @@ Record in saved report metadata, e.g. `framework: xgboost`, `xgboost_version`, b
 
 ## Suggested PR breakdown
 
-1. **PR A — Resolver + sklearn parity**  
+1. **PR A — Resolver + sklearn parity**
    Introduce `resolve_predictions`; wire `analyze()`; no XGBoost yet; tests prove identical behavior to today.
 
-2. **PR B — XGBoost**  
+2. **PR B — XGBoost**
    Optional extra, branch, tests, docs — isolated revert surface.
 
 ---
@@ -137,10 +137,10 @@ Record in saved report metadata, e.g. `framework: xgboost`, `xgboost_version`, b
 
 ## FAQ
 
-**Q: LightGBM / CatBoost?**  
+**Q: LightGBM / CatBoost?**
 **A:** Often work today via `predict` / `predict_proba`. Add library-specific tests in follow-up PRs; open a dedicated plan only if a quirk requires a new branch.
 
-**Q: Order relative to Keras / TensorFlow?**  
+**Q: Order relative to Keras / TensorFlow?**
 **A:** Independent once PR A exists. XGBoost is lighter and is a good first optional backend.
 
 ---


### PR DESCRIPTION
## Overview
This PR introduces detailed implementation plans for integrating **XGBoost**, **Keras**, and **TensorFlow** into TrustLens. It also updates the roadmap and contributing guidelines to reflect these new development priorities.

## Key Changes
- **New Plans**: Added three technical specifications in `docs/plans/` covering architectural requirements, lazy imports, and shape normalization for major ML frameworks.
- **Roadmap Update**: Marked v0.3.0 features as complete and added framework integration to the "Active Work" cycle.
- **Contributing Guide**: Added instructions for running framework-specific tests using pytest markers (`requires_xgboost`, `requires_tensorflow`).

## Technical Highlights
- **Resolver Pattern**: All plans align on a shared `resolve_predictions` pattern to keep the core API clean and decoupled from framework specifics.
- **Import Hygiene**: Strictly enforces lazy imports to ensure `import trustlens` remains lightweight and dependency-free.
- **Experimental Guardrails**: Keras and TensorFlow are categorized as "Experimental" modules in the roadmap until promotion criteria are met.