### PR TITLE
resolved the xgboost.core.XGBoostError: XGBoost Library (libxgboost.d…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
+      - name: Install OpenMP (macOS)
+        if: runner.os == 'macOS'
+        run: brew install libomp
       - name: Install dependencies
         run: |
           pip install -e ".[dev,full]"


### PR DESCRIPTION
Fixed the `.github/workflows/ci.yml`.

The error log indicates that `XGBoost` is missing the `OpenMP` runtime dependency (`libomp`) specifically on macOS environments, which is a known issue since macOS doesn't include OpenMP by default.