### PR TITLE
Fix global misclassification indices

### DIFF
--- a/tests/characterization/baselines.json
+++ b/tests/characterization/baselines.json
@@ -45,7 +45,7 @@
             "error_rate": 0.02,
             "avg_misclassification_confidence": 0.7,
             "top_mistake_indices": [
-              0
+              80
             ]
           },
           "1": {
@@ -54,11 +54,11 @@
             "error_rate": 0.2,
             "avg_misclassification_confidence": 0.65,
             "top_mistake_indices": [
-              0,
-              9,
-              8,
               3,
-              7
+              93,
+              79,
+              38,
+              71
             ]
           },
           "__overall__": {
@@ -318,11 +318,11 @@
             "error_rate": 0.1,
             "avg_misclassification_confidence": 0.6744,
             "top_mistake_indices": [
-              4,
-              2,
-              1,
-              0,
-              3
+              80,
+              61,
+              45,
+              32,
+              77
             ]
           },
           "1": {
@@ -331,11 +331,11 @@
             "error_rate": 0.26,
             "avg_misclassification_confidence": 0.6985,
             "top_mistake_indices": [
-              6,
-              8,
-              7,
-              5,
-              10
+              59,
+              79,
+              73,
+              48,
+              93
             ]
           },
           "__overall__": {

--- a/tests/test_failure.py
+++ b/tests/test_failure.py
@@ -49,6 +49,25 @@ class TestMisclassificationSummary:
         summary = misclassification_summary(y_true, y_true, np.eye(2)[y_true])
         assert summary["__overall__"]["total_errors"] == 0
 
+    def test_top_mistake_indices_are_global_dataset_indices(self):
+        y_true = np.array([0, 0, 0, 1, 1, 1])
+        y_pred = np.array([0, 1, 0, 1, 0, 1])
+        y_prob = np.array(
+            [
+                [0.9, 0.1],
+                [0.2, 0.8],
+                [0.7, 0.3],
+                [0.1, 0.9],
+                [0.9, 0.1],
+                [0.2, 0.8],
+            ]
+        )
+
+        summary = misclassification_summary(y_true, y_pred, y_prob)
+
+        assert summary[0]["top_mistake_indices"] == [1]
+        assert summary[1]["top_mistake_indices"] == [4]
+
 
 class TestConfidenceGap:
     def test_gap_nonnegative_for_good_model(self, binary_data):

--- a/trustlens/metrics/failure.py
+++ b/trustlens/metrics/failure.py
@@ -81,7 +81,9 @@ def misclassification_summary(
         # Indices of top-5 most confident mistakes (high-confidence errors)
         if len(miscls_confidences) > 0:
             topk = min(5, len(miscls_confidences))
-            top_mistake_indices = np.argsort(miscls_confidences)[-topk:][::-1].tolist()
+            local_indices = np.argsort(miscls_confidences)[-topk:][::-1]
+            global_indices = np.where(cls_incorrect)[0]
+            top_mistake_indices = global_indices[local_indices].tolist()
         else:
             top_mistake_indices = []
 


### PR DESCRIPTION
## Summary
- Map `misclassification_summary` top mistake positions back to original dataset indices.
- Add a regression test for the issue #103 repro so class-level mistakes report `[1]` and `[4]`, not local subset positions.

## Verification
- `uv run --with pytest --with numpy --with scikit-learn --with matplotlib --with scipy pytest tests/test_failure.py -q` -> 8 passed
- `uv run --with ruff ruff check trustlens/metrics/failure.py tests/test_failure.py` -> All checks passed
- `git diff --check`

Fixes #103.

Optional: if this saves you time and you want to send a small thank-you after review/merge, I use this $5 checkout for tiny fixes: https://nicdunz.gumroad.com/l/tiny-codex-teardown-direct?wanted=true

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed index mapping in misclassification metrics to correctly reference original dataset positions instead of per-class offsets.

* **Tests**
  * Added test validation to ensure misclassification indices accurately map to global dataset positions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Khanz9664/TrustLens/pull/104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->