### PR TITLE
docs: improve analyze() docstring with full runnable example

### DIFF
--- a/trustlens/api.py
+++ b/trustlens/api.py
@@ -120,6 +120,38 @@ def analyze(
     -------
     TrustReport
       Populated report object with metrics, plots, and narrative summaries.
+
+    Examples
+    --------
+    End-to-end analysis with a RandomForest classifier:
+
+    >>> from sklearn.datasets import make_classification
+    >>> from sklearn.ensemble import RandomForestClassifier
+    >>> from sklearn.model_selection import train_test_split
+    >>> from trustlens import analyze
+    >>>
+    >>> # Create a synthetic dataset
+    >>> X, y = make_classification(
+    ...     n_samples=500, n_features=10, random_state=42
+    ... )
+    >>>
+    >>> # Train / test split
+    >>> X_train, X_test, y_train, y_test = train_test_split(
+    ...     X, y, test_size=0.3, random_state=42
+    ... )
+    >>>
+    >>> # Train a classifier
+    >>> model = RandomForestClassifier(random_state=42)
+    >>> model.fit(X_train, y_train)
+    >>>
+    >>> # Predict probabilities
+    >>> y_prob = model.predict_proba(X_test)
+    >>>
+    >>> # Run TrustLens analysis
+    >>> report = analyze(model, X_test, y_test, y_prob=y_prob)
+    >>>
+    >>> # Display results
+    >>> report.show()
     """
     if len(y_true) < 30:
         logger.warning("Small dataset (n < 30) detected. Calibration metrics may be unreliable.")


### PR DESCRIPTION
## Summary

Closes #22

Added a complete, copy-paste runnable example to the `analyze()` docstring that demonstrates:

- Dataset creation using `make_classification`
- Train/test split
- Training a `RandomForestClassifier`
- Predicting probabilities
- Running `analyze()`
- Displaying results with `report.show()`

## Changes

- `trustlens/api.py`: Added `Examples` section to `analyze()` docstring with a full end-to-end runnable example

## Testing

- The example code follows the exact pattern suggested in the issue
- Uses standard sklearn imports that are already project dependencies
- Follows NumPy docstring conventions for the `Examples` section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive usage examples to the `analyze` function documentation, including an end-to-end workflow demonstrating dataset creation, model training, probability prediction, and function invocation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Khanz9664/TrustLens/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->