### PR TITLE
feat: regression analysis path + TrustReport integration (#82)

### DIFF
--- a/tests/test_regression_pipeline.py
+++ b/tests/test_regression_pipeline.py
@@ -26,14 +26,18 @@ def regression_data():
 
 def test_explicit_regression_routes_and_skips_trust_score(regression_data):
     X, y_true, y_pred = regression_data
-    rep = analyze(model=None, X=X, y_true=y_true, y_pred=y_pred,
-                  task="regression", verbose=False)
+    rep = analyze(model=None, X=X, y_true=y_true, y_pred=y_pred, task="regression", verbose=False)
     assert isinstance(rep, TrustReport)
     assert rep.task_type == "regression"
     assert rep.trust_score is None  # classification score intentionally absent
     ed = rep.results["regression"]["error_distribution"]
-    for key in ("mean_absolute_error", "rmse", "median_absolute_error",
-                "p90_absolute_error", "max_error"):
+    for key in (
+        "mean_absolute_error",
+        "rmse",
+        "median_absolute_error",
+        "p90_absolute_error",
+        "max_error",
+    ):
         assert key in ed
     assert rep.metadata["task_type"] == "regression"
     assert "n_classes" not in rep.metadata
@@ -43,21 +47,20 @@ def test_explicit_regression_routes_and_skips_trust_score(regression_data):
 def test_auto_detection(regression_data):
     X, y_true, y_pred = regression_data
     # Continuous target -> regression.
-    rep = analyze(model=None, X=X, y_true=y_true, y_pred=y_pred,
-                  task="auto", verbose=False)
+    rep = analyze(model=None, X=X, y_true=y_true, y_pred=y_pred, task="auto", verbose=False)
     assert rep.task_type == "regression"
     # Integer label target -> classification (not routed to regression).
     y_cls = (y_true > np.median(y_true)).astype(int)
     yprob = np.column_stack([1 - y_cls, y_cls]).astype(float)
-    rep_cls = analyze(model=None, X=X, y_true=y_cls, y_pred=y_cls, y_prob=yprob,
-                      task="auto", verbose=False)
+    rep_cls = analyze(
+        model=None, X=X, y_true=y_cls, y_pred=y_cls, y_prob=yprob, task="auto", verbose=False
+    )
     assert rep_cls.task_type == "classification"
 
 
 def test_show_renders_regression(regression_data, capsys):
     X, y_true, y_pred = regression_data
-    rep = analyze(model=None, X=X, y_true=y_true, y_pred=y_pred,
-                  task="regression", verbose=False)
+    rep = analyze(model=None, X=X, y_true=y_true, y_pred=y_pred, task="regression", verbose=False)
     rep.show()
     out = capsys.readouterr().out
     assert "Regression Reliability Report" in out
@@ -67,8 +70,7 @@ def test_show_renders_regression(regression_data, capsys):
 
 def test_to_dict_serializes_regression(regression_data):
     X, y_true, y_pred = regression_data
-    rep = analyze(model=None, X=X, y_true=y_true, y_pred=y_pred,
-                  task="regression", verbose=False)
+    rep = analyze(model=None, X=X, y_true=y_true, y_pred=y_pred, task="regression", verbose=False)
     d = rep.to_dict()
     assert d["task_type"] == "regression"
     assert "regression.error_distribution.rmse" in d
@@ -82,9 +84,17 @@ def test_uncertainty_metrics_populated_when_supplied(regression_data):
     X, y_true, y_pred = regression_data
     lo, hi = y_pred - 2.0, y_pred + 2.0
     variance = np.abs(y_true - y_pred)  # perfectly tracks error
-    rep = analyze(model=None, X=X, y_true=y_true, y_pred=y_pred, task="regression",
-                  prediction_intervals=(lo, hi), predicted_variance=variance,
-                  confidence_level=0.95, verbose=False)
+    rep = analyze(
+        model=None,
+        X=X,
+        y_true=y_true,
+        y_pred=y_pred,
+        task="regression",
+        prediction_intervals=(lo, hi),
+        predicted_variance=variance,
+        confidence_level=0.95,
+        verbose=False,
+    )
     reg = rep.results["regression"]
     picp = reg["interval_coverage"]
     assert "picp" in picp and 0.0 <= picp["picp"] <= 1.0
@@ -95,8 +105,7 @@ def test_uncertainty_metrics_populated_when_supplied(regression_data):
 
 def test_uncertainty_metrics_skip_gracefully(regression_data):
     X, y_true, y_pred = regression_data
-    rep = analyze(model=None, X=X, y_true=y_true, y_pred=y_pred,
-                  task="regression", verbose=False)
+    rep = analyze(model=None, X=X, y_true=y_true, y_pred=y_pred, task="regression", verbose=False)
     reg = rep.results["regression"]
     assert reg["interval_coverage"]["status"] == "skipped"
     assert reg["error_variance_correlation"]["status"] == "skipped"
@@ -118,8 +127,7 @@ def test_model_predict_path():
 
 def test_classification_features_guarded_on_regression(regression_data):
     X, y_true, y_pred = regression_data
-    rep = analyze(model=None, X=X, y_true=y_true, y_pred=y_pred,
-                  task="regression", verbose=False)
+    rep = analyze(model=None, X=X, y_true=y_true, y_pred=y_pred, task="regression", verbose=False)
     for call in (
         lambda: rep.summary_plot(show=False),
         lambda: rep.plot(),
@@ -134,8 +142,7 @@ def test_save_roundtrip_regression(regression_data, tmp_path):
     import json
 
     X, y_true, y_pred = regression_data
-    rep = analyze(model=None, X=X, y_true=y_true, y_pred=y_pred,
-                  task="regression", verbose=False)
+    rep = analyze(model=None, X=X, y_true=y_true, y_pred=y_pred, task="regression", verbose=False)
     # JSON
     jp = rep.save(str(tmp_path / "reg.json"))
     data = json.loads(jp.read_text(encoding="utf-8"))
@@ -149,8 +156,7 @@ def test_save_roundtrip_regression(regression_data, tmp_path):
 def test_invalid_task_raises(regression_data):
     X, y_true, y_pred = regression_data
     with pytest.raises(ValueError):
-        analyze(model=None, X=X, y_true=y_true, y_pred=y_pred,
-                task="nonsense", verbose=False)
+        analyze(model=None, X=X, y_true=y_true, y_pred=y_pred, task="nonsense", verbose=False)
 
 
 def test_multiclass_float_labels_route_to_classification():
@@ -162,8 +168,9 @@ def test_multiclass_float_labels_route_to_classification():
     y_cls = rng.integers(0, 25, size=n).astype(float)  # 25 integer classes as float
     assert len(np.unique(y_cls)) > 20
     yprob = np.full((n, 25), 1 / 25)
-    rep = analyze(model=None, X=X, y_true=y_cls, y_pred=y_cls, y_prob=yprob,
-                  task="auto", verbose=False)
+    rep = analyze(
+        model=None, X=X, y_true=y_cls, y_pred=y_cls, y_prob=yprob, task="auto", verbose=False
+    )
     assert rep.task_type == "classification"
 
 
@@ -175,20 +182,30 @@ def test_singleton_column_predictions_flattened():
     X = rng.normal(size=(n, 2))
     y_true = (X @ np.array([1.0, -0.5])) + rng.normal(scale=0.3, size=n)
     y_pred_2d = (y_true + rng.normal(scale=0.3, size=n)).reshape(-1, 1)  # (n, 1)
-    rep = analyze(model=None, X=X, y_true=y_true.reshape(-1, 1), y_pred=y_pred_2d,
-                  task="regression", verbose=False)
+    rep = analyze(
+        model=None,
+        X=X,
+        y_true=y_true.reshape(-1, 1),
+        y_pred=y_pred_2d,
+        task="regression",
+        verbose=False,
+    )
     assert rep.results["regression"]["error_distribution"]["n_samples"] == n
     # True multi-output is rejected, not silently mis-shaped.
     with pytest.raises(ValueError):
-        analyze(model=None, X=X, y_true=y_true,
-                y_pred=np.column_stack([y_pred_2d[:, 0], y_pred_2d[:, 0]]),
-                task="regression", verbose=False)
+        analyze(
+            model=None,
+            X=X,
+            y_true=y_true,
+            y_pred=np.column_stack([y_pred_2d[:, 0], y_pred_2d[:, 0]]),
+            task="regression",
+            verbose=False,
+        )
 
 
 def test_to_dict_includes_regression_metadata(regression_data):
     X, y_true, y_pred = regression_data
-    rep = analyze(model=None, X=X, y_true=y_true, y_pred=y_pred,
-                  task="regression", verbose=False)
+    rep = analyze(model=None, X=X, y_true=y_true, y_pred=y_pred, task="regression", verbose=False)
     d = rep.to_dict()
     assert d["n_samples"] == len(y_true)
     assert d["model"] == "Manual"

--- a/tests/test_regression_pipeline.py
+++ b/tests/test_regression_pipeline.py
@@ -1,0 +1,153 @@
+"""Tests for the regression analysis path: task routing + TrustReport integration.
+
+Covers analyze() task detection/routing, regression metric surfacing in the
+report, show() rendering, to_dict() serialization, save() round-trips, and that
+classification-only features are cleanly guarded on a regression report.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from trustlens import analyze
+from trustlens.report import TrustReport
+
+
+@pytest.fixture
+def regression_data():
+    rng = np.random.default_rng(42)
+    n = 200
+    X = rng.normal(size=(n, 3))
+    y_true = X @ np.array([1.5, -2.0, 0.7]) + rng.normal(scale=1.0, size=n)
+    y_pred = y_true + rng.normal(scale=1.0, size=n)
+    return X, y_true, y_pred
+
+
+def test_explicit_regression_routes_and_skips_trust_score(regression_data):
+    X, y_true, y_pred = regression_data
+    rep = analyze(model=None, X=X, y_true=y_true, y_pred=y_pred,
+                  task="regression", verbose=False)
+    assert isinstance(rep, TrustReport)
+    assert rep.task_type == "regression"
+    assert rep.trust_score is None  # classification score intentionally absent
+    ed = rep.results["regression"]["error_distribution"]
+    for key in ("mean_absolute_error", "rmse", "median_absolute_error",
+                "p90_absolute_error", "max_error"):
+        assert key in ed
+    assert rep.metadata["task_type"] == "regression"
+    assert "n_classes" not in rep.metadata
+    assert rep.metadata["n_unique_targets"] == len(np.unique(y_true))
+
+
+def test_auto_detection(regression_data):
+    X, y_true, y_pred = regression_data
+    # Continuous target -> regression.
+    rep = analyze(model=None, X=X, y_true=y_true, y_pred=y_pred,
+                  task="auto", verbose=False)
+    assert rep.task_type == "regression"
+    # Integer label target -> classification (not routed to regression).
+    y_cls = (y_true > np.median(y_true)).astype(int)
+    yprob = np.column_stack([1 - y_cls, y_cls]).astype(float)
+    rep_cls = analyze(model=None, X=X, y_true=y_cls, y_pred=y_cls, y_prob=yprob,
+                      task="auto", verbose=False)
+    assert rep_cls.task_type == "classification"
+
+
+def test_show_renders_regression(regression_data, capsys):
+    X, y_true, y_pred = regression_data
+    rep = analyze(model=None, X=X, y_true=y_true, y_pred=y_pred,
+                  task="regression", verbose=False)
+    rep.show()
+    out = capsys.readouterr().out
+    assert "Regression Reliability Report" in out
+    assert "MAE" in out and "RMSE" in out
+    assert "Task      : regression" in out
+
+
+def test_to_dict_serializes_regression(regression_data):
+    X, y_true, y_pred = regression_data
+    rep = analyze(model=None, X=X, y_true=y_true, y_pred=y_pred,
+                  task="regression", verbose=False)
+    d = rep.to_dict()
+    assert d["task_type"] == "regression"
+    assert "regression.error_distribution.rmse" in d
+    assert isinstance(d["regression.error_distribution.rmse"], float)
+    # No classification trust score leaks into a regression dict.
+    assert "trust_score" not in d
+    assert "trust_grade" not in d
+
+
+def test_uncertainty_metrics_populated_when_supplied(regression_data):
+    X, y_true, y_pred = regression_data
+    lo, hi = y_pred - 2.0, y_pred + 2.0
+    variance = np.abs(y_true - y_pred)  # perfectly tracks error
+    rep = analyze(model=None, X=X, y_true=y_true, y_pred=y_pred, task="regression",
+                  prediction_intervals=(lo, hi), predicted_variance=variance,
+                  confidence_level=0.95, verbose=False)
+    reg = rep.results["regression"]
+    picp = reg["interval_coverage"]
+    assert "picp" in picp and 0.0 <= picp["picp"] <= 1.0
+    assert picp["target_coverage"] == 0.95
+    corr = reg["error_variance_correlation"]
+    assert corr["verdict"] == "informative"  # variance == error => strong corr
+
+
+def test_uncertainty_metrics_skip_gracefully(regression_data):
+    X, y_true, y_pred = regression_data
+    rep = analyze(model=None, X=X, y_true=y_true, y_pred=y_pred,
+                  task="regression", verbose=False)
+    reg = rep.results["regression"]
+    assert reg["interval_coverage"]["status"] == "skipped"
+    assert reg["error_variance_correlation"]["status"] == "skipped"
+
+
+def test_model_predict_path():
+    from sklearn.linear_model import LinearRegression
+
+    rng = np.random.default_rng(0)
+    n = 120
+    X = rng.normal(size=(n, 4))
+    y = X @ np.array([1.0, 0.5, -1.0, 2.0]) + rng.normal(scale=0.5, size=n)
+    model = LinearRegression().fit(X, y)
+    # No y_pred given -> resolved via model.predict.
+    rep = analyze(model=model, X=X, y_true=y, task="regression", verbose=False)
+    assert rep.task_type == "regression"
+    assert rep.results["regression"]["error_distribution"]["n_samples"] == n
+
+
+def test_classification_features_guarded_on_regression(regression_data):
+    X, y_true, y_pred = regression_data
+    rep = analyze(model=None, X=X, y_true=y_true, y_pred=y_pred,
+                  task="regression", verbose=False)
+    for call in (
+        lambda: rep.summary_plot(show=False),
+        lambda: rep.plot(),
+        lambda: rep.show_failures(),
+        lambda: rep.deployment_explanation,
+    ):
+        with pytest.raises(NotImplementedError):
+            call()
+
+
+def test_save_roundtrip_regression(regression_data, tmp_path):
+    import json
+
+    X, y_true, y_pred = regression_data
+    rep = analyze(model=None, X=X, y_true=y_true, y_pred=y_pred,
+                  task="regression", verbose=False)
+    # JSON
+    jp = rep.save(str(tmp_path / "reg.json"))
+    data = json.loads(jp.read_text(encoding="utf-8"))
+    assert data["task_type"] == "regression"
+    assert "regression" in data["results"]
+    # TXT
+    tp = rep.save(str(tmp_path / "reg.txt"))
+    assert "Regression Reliability Report" in tp.read_text(encoding="utf-8")
+
+
+def test_invalid_task_raises(regression_data):
+    X, y_true, y_pred = regression_data
+    with pytest.raises(ValueError):
+        analyze(model=None, X=X, y_true=y_true, y_pred=y_pred,
+                task="nonsense", verbose=False)

--- a/tests/test_regression_pipeline.py
+++ b/tests/test_regression_pipeline.py
@@ -151,3 +151,45 @@ def test_invalid_task_raises(regression_data):
     with pytest.raises(ValueError):
         analyze(model=None, X=X, y_true=y_true, y_pred=y_pred,
                 task="nonsense", verbose=False)
+
+
+def test_multiclass_float_labels_route_to_classification():
+    """A 25-class label set encoded as float must NOT be mistaken for
+    regression — integer-valued floats are class labels at any cardinality."""
+    rng = np.random.default_rng(7)
+    n = 300
+    X = rng.normal(size=(n, 3))
+    y_cls = rng.integers(0, 25, size=n).astype(float)  # 25 integer classes as float
+    assert len(np.unique(y_cls)) > 20
+    yprob = np.full((n, 25), 1 / 25)
+    rep = analyze(model=None, X=X, y_true=y_cls, y_pred=y_cls, y_prob=yprob,
+                  task="auto", verbose=False)
+    assert rep.task_type == "classification"
+
+
+def test_singleton_column_predictions_flattened():
+    """`(n, 1)` predictions (valid single-output) flatten rather than crash;
+    a true multi-output shape is rejected with a clear error."""
+    rng = np.random.default_rng(11)
+    n = 150
+    X = rng.normal(size=(n, 2))
+    y_true = (X @ np.array([1.0, -0.5])) + rng.normal(scale=0.3, size=n)
+    y_pred_2d = (y_true + rng.normal(scale=0.3, size=n)).reshape(-1, 1)  # (n, 1)
+    rep = analyze(model=None, X=X, y_true=y_true.reshape(-1, 1), y_pred=y_pred_2d,
+                  task="regression", verbose=False)
+    assert rep.results["regression"]["error_distribution"]["n_samples"] == n
+    # True multi-output is rejected, not silently mis-shaped.
+    with pytest.raises(ValueError):
+        analyze(model=None, X=X, y_true=y_true,
+                y_pred=np.column_stack([y_pred_2d[:, 0], y_pred_2d[:, 0]]),
+                task="regression", verbose=False)
+
+
+def test_to_dict_includes_regression_metadata(regression_data):
+    X, y_true, y_pred = regression_data
+    rep = analyze(model=None, X=X, y_true=y_true, y_pred=y_pred,
+                  task="regression", verbose=False)
+    d = rep.to_dict()
+    assert d["n_samples"] == len(y_true)
+    assert d["model"] == "Manual"
+    assert "timestamp" in d and "trustlens_version" in d

--- a/trustlens/api.py
+++ b/trustlens/api.py
@@ -42,9 +42,7 @@ def _detect_task(y_true: np.ndarray, task: str) -> str:
     if task in ("classification", "regression"):
         return task
     if task != "auto":
-        raise ValueError(
-            f"Invalid task {task!r}. Use 'auto', 'classification', or 'regression'."
-        )
+        raise ValueError(f"Invalid task {task!r}. Use 'auto', 'classification', or 'regression'.")
 
     y = np.asarray(y_true)
     if y.dtype.kind == "f":

--- a/trustlens/api.py
+++ b/trustlens/api.py
@@ -50,8 +50,11 @@ def _detect_task(y_true: np.ndarray, task: str) -> str:
     if y.dtype.kind == "f":
         n_unique = len(np.unique(y))
         is_integer_valued = bool(np.all(np.isfinite(y))) and bool(np.allclose(y, np.round(y)))
-        # Integer-valued floats with a small label set look like classes.
-        if is_integer_valued and n_unique <= 20:
+        # Integer-valued floats are class labels at ANY cardinality (a 25-class
+        # target encoded as float must not be mistaken for regression), and a
+        # small distinct-value set is also label-like. Only clearly-continuous
+        # floats route to regression.
+        if is_integer_valued or n_unique <= 20:
             return "classification"
         return "regression"
     # Non-float dtypes (ints, strings, bools) default to classification.

--- a/trustlens/api.py
+++ b/trustlens/api.py
@@ -24,10 +24,38 @@ from typing import Any, Optional
 import numpy as np
 
 from trustlens.backends.registry import get_resolver
-from trustlens.core.pipeline import _run_analysis_pipeline
+from trustlens.core.pipeline import _run_analysis_pipeline, _run_regression_pipeline
 from trustlens.report import TrustReport
 
 logger = logging.getLogger(__name__)
+
+
+def _detect_task(y_true: np.ndarray, task: str) -> str:
+    """Resolve the analysis task type.
+
+    ``task`` may be ``"classification"`` / ``"regression"`` (explicit, honored
+    as-is) or ``"auto"``. Auto-detection errs toward ``"classification"`` and
+    only returns ``"regression"`` when the target is clearly continuous — a
+    float array that is not integer-valued, or has many distinct values — so a
+    discrete label set is never mis-routed.
+    """
+    if task in ("classification", "regression"):
+        return task
+    if task != "auto":
+        raise ValueError(
+            f"Invalid task {task!r}. Use 'auto', 'classification', or 'regression'."
+        )
+
+    y = np.asarray(y_true)
+    if y.dtype.kind == "f":
+        n_unique = len(np.unique(y))
+        is_integer_valued = bool(np.all(np.isfinite(y))) and bool(np.allclose(y, np.round(y)))
+        # Integer-valued floats with a small label set look like classes.
+        if is_integer_valued and n_unique <= 20:
+            return "classification"
+        return "regression"
+    # Non-float dtypes (ints, strings, bools) default to classification.
+    return "classification"
 
 
 def quick_analyze(
@@ -107,6 +135,10 @@ def analyze(
     modules: Optional[list[str]] = None,
     plugins: Optional[list[str]] = None,
     class_labels: Optional[np.ndarray] = None,
+    task: str = "auto",
+    prediction_intervals: Optional[tuple[np.ndarray, np.ndarray]] = None,
+    predicted_variance: Optional[np.ndarray] = None,
+    confidence_level: float = 0.95,
     verbose: bool = True,
 ) -> TrustReport:
     """
@@ -143,6 +175,20 @@ def analyze(
       Semantic class labels in the order corresponding to probability columns.
       Useful for raw backends such as ``xgboost.Booster`` that return ordinal
       probability columns without a ``classes_`` attribute.
+    task : str, default='auto'
+      Analysis task: ``'auto'`` (detect from ``y_true``), ``'classification'``,
+      or ``'regression'``. Regression routes through the regression reliability
+      metrics (error distribution, interval coverage, error-variance
+      correlation) instead of the classification modules.
+    prediction_intervals : tuple(np.ndarray, np.ndarray), optional
+      ``(lower, upper)`` per-sample prediction-interval bounds (regression only).
+      Enables Prediction Interval Coverage (PICP); omitted ⇒ that metric is
+      skipped.
+    predicted_variance : np.ndarray, optional
+      Per-sample predicted variance / uncertainty score (regression only).
+      Enables the error-variance correlation metric; omitted ⇒ skipped.
+    confidence_level : float, default=0.95
+      Nominal coverage the supplied ``prediction_intervals`` claim (regression).
     verbose : bool
       Print progress updates. Default True.
 
@@ -184,7 +230,35 @@ def analyze(
     >>> report.show()
     """
     if len(y_true) < 30:
-        logger.warning("Small dataset (n < 30) detected. Calibration metrics may be unreliable.")
+        logger.warning("Small dataset (n < 30) detected. Metrics may be unreliable.")
+
+    # ------------------------------------------------------------------
+    # 0. Route by task. Regression skips the classification backend (which
+    #    resolves class probabilities) and the classification modules.
+    # ------------------------------------------------------------------
+    task_type = _detect_task(y_true, task)
+    if task_type == "regression":
+        if y_pred is None:
+            if model is None or not hasattr(model, "predict"):
+                raise ValueError(
+                    "Regression analysis needs point predictions: pass y_pred=..., "
+                    "or a model that exposes .predict(X)."
+                )
+            y_pred_resolved = np.asarray(model.predict(X))
+        else:
+            y_pred_resolved = np.asarray(y_pred)
+        return _run_regression_pipeline(
+            model=model,
+            X=X,
+            y_true=np.asarray(y_true),
+            y_pred=y_pred_resolved,
+            prediction_intervals=prediction_intervals,
+            predicted_variance=predicted_variance,
+            confidence_level=confidence_level,
+            framework=framework or ("manual" if y_pred is not None else None),
+            backend_metadata={"task_type": "regression"},
+            verbose=verbose,
+        )
 
     # ------------------------------------------------------------------
     # 1. Resolve predictions via Backend Registry

--- a/trustlens/core/pipeline.py
+++ b/trustlens/core/pipeline.py
@@ -39,6 +39,11 @@ from trustlens.metrics.failure import (
     confidence_gap,
     misclassification_summary,
 )
+from trustlens.metrics.regression import (
+    error_distribution,
+    error_variance_correlation,
+    prediction_interval_coverage,
+)
 from trustlens.metrics.representation import (
     embedding_separability,
 )
@@ -299,5 +304,68 @@ def _run_analysis_pipeline(
         embeddings=embeddings,
         framework=framework,
         backend_metadata=backend_metadata,
+    )
+    return report
+
+
+def _run_regression_pipeline(
+    model: Any,
+    X: np.ndarray,
+    y_true: np.ndarray,
+    y_pred: np.ndarray,
+    prediction_intervals: Optional[tuple[np.ndarray, np.ndarray]] = None,
+    predicted_variance: Optional[np.ndarray] = None,
+    confidence_level: float = 0.95,
+    framework: Optional[str] = None,
+    backend_metadata: Optional[dict[str, Any]] = None,
+    verbose: bool = True,
+) -> TrustReport:
+    """Internal orchestrator for the regression analysis path.
+
+    Mirrors :func:`_run_analysis_pipeline` (metrics -> results dict -> report)
+    but routes through the regression reliability metrics. The uncertainty
+    metrics (PICP, error-variance correlation) degrade gracefully to a
+    ``status="skipped"`` dict when their optional inputs are absent.
+
+    As with the classification path, this never calls ``model.predict``; the
+    point predictions (and any intervals / variance) are passed in.
+    """
+    _log = logger.info if verbose else logger.debug
+
+    y_true = np.asarray(y_true)
+    y_pred = np.asarray(y_pred)
+
+    lower = upper = None
+    if prediction_intervals is not None:
+        lower, upper = prediction_intervals
+
+    print("Running regression reliability analysis...")
+    regression_results: dict[str, Any] = {
+        "error_distribution": error_distribution(y_true, y_pred),
+        "interval_coverage": prediction_interval_coverage(
+            y_true, lower, upper, confidence_level=confidence_level
+        ),
+        "error_variance_correlation": error_variance_correlation(
+            y_true, y_pred, predicted_variance
+        ),
+    }
+
+    results: dict[str, Any] = {"regression": regression_results}
+
+    _log("Assembling regression report …")
+    if backend_metadata is None:
+        backend_metadata = {}
+
+    report = TrustReport(
+        results=results,
+        model=model,
+        X=X,
+        y_true=y_true,
+        y_pred=y_pred,
+        y_prob=None,
+        embeddings=None,
+        framework=framework,
+        backend_metadata=backend_metadata,
+        task_type="regression",
     )
     return report

--- a/trustlens/core/pipeline.py
+++ b/trustlens/core/pipeline.py
@@ -21,7 +21,7 @@ to domain-specific modules (`trustlens.metrics.*`).
 from __future__ import annotations
 
 import logging
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 import numpy as np
 
@@ -332,21 +332,40 @@ def _run_regression_pipeline(
     """
     _log = logger.info if verbose else logger.debug
 
-    y_true = np.asarray(y_true)
-    y_pred = np.asarray(y_pred)
+    def _as_single_output(name: str, values: np.ndarray) -> np.ndarray:
+        """Coerce to 1-D: flatten a singleton ``(n, 1)`` column; reject true
+        multi-output. A single-output model emitting ``(n, 1)`` predictions is
+        valid and must not crash the metrics with a shape mismatch."""
+        arr = np.asarray(values)
+        if arr.ndim == 2 and arr.shape[1] == 1:
+            return cast(np.ndarray, arr[:, 0])
+        if arr.ndim != 1:
+            raise ValueError(
+                f"{name} must be 1-D for single-output regression, got shape {arr.shape}."
+            )
+        return cast(np.ndarray, arr)
+
+    y_true = _as_single_output("y_true", y_true)
+    y_pred = _as_single_output("y_pred", y_pred)
 
     lower = upper = None
     if prediction_intervals is not None:
         lower, upper = prediction_intervals
+        lower = _as_single_output("prediction_intervals[0]", lower)
+        upper = _as_single_output("prediction_intervals[1]", upper)
 
-    print("Running regression reliability analysis...")
+    variance = predicted_variance
+    if variance is not None:
+        variance = _as_single_output("predicted_variance", variance)
+
+    _log("Running regression reliability analysis...")
     regression_results: dict[str, Any] = {
         "error_distribution": error_distribution(y_true, y_pred),
         "interval_coverage": prediction_interval_coverage(
             y_true, lower, upper, confidence_level=confidence_level
         ),
         "error_variance_correlation": error_variance_correlation(
-            y_true, y_pred, predicted_variance
+            y_true, y_pred, variance
         ),
     }
 

--- a/trustlens/core/pipeline.py
+++ b/trustlens/core/pipeline.py
@@ -364,9 +364,7 @@ def _run_regression_pipeline(
         "interval_coverage": prediction_interval_coverage(
             y_true, lower, upper, confidence_level=confidence_level
         ),
-        "error_variance_correlation": error_variance_correlation(
-            y_true, y_pred, variance
-        ),
+        "error_variance_correlation": error_variance_correlation(y_true, y_pred, variance),
     }
 
     results: dict[str, Any] = {"regression": regression_results}

--- a/trustlens/report.py
+++ b/trustlens/report.py
@@ -463,10 +463,7 @@ class TrustReport:
                 print(f"\n{module_name.title()} Analysis")
                 print(out)
 
-        if (
-            pic.get("status") == "skipped"
-            and evc.get("status") == "skipped"
-        ):
+        if pic.get("status") == "skipped" and evc.get("status") == "skipped":
             print(
                 "\nNote: uncertainty metrics (PICP, error-variance correlation) need "
                 "prediction intervals / predicted variance. Pass prediction_intervals "

--- a/trustlens/report.py
+++ b/trustlens/report.py
@@ -23,8 +23,10 @@ It relies on `trustlens.trust_score` to compute the composite Trust Score.
 
 from __future__ import annotations
 
+import io
 import json
 import logging
+from contextlib import redirect_stdout
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, cast
@@ -453,9 +455,6 @@ class TrustReport:
         for module_name, module_data in self.results.items():
             if module_name == "regression":
                 continue
-            import io
-            from contextlib import redirect_stdout
-
             f = io.StringIO()
             with redirect_stdout(f):
                 self._print_module(module_data, indent=0, verbose=verbose)
@@ -477,9 +476,6 @@ class TrustReport:
 
     def _generate_regression_text(self, verbose: bool = False) -> str:
         """Plain-text regression report (captures _show_regression's output)."""
-        import io
-        from contextlib import redirect_stdout
-
         f = io.StringIO()
         with redirect_stdout(f):
             self._show_regression(verbose=verbose)
@@ -1615,6 +1611,9 @@ class TrustReport:
         # deployment verdict — return the flattened reliability metrics + meta.
         if self.task_type == "regression":
             flat["task_type"] = "regression"
+            flat["n_samples"] = self.metadata["n_samples"]
+            flat["model"] = self.metadata["model_class"]
+            flat["timestamp"] = self.metadata["timestamp"]
             flat["framework"] = self.metadata.get("framework", "unknown")
             flat["trustlens_version"] = self.metadata["trustlens_version"]
             return flat

--- a/trustlens/report.py
+++ b/trustlens/report.py
@@ -27,13 +27,16 @@ import json
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Optional, cast
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 import numpy as np
 
 from trustlens.visualization.style import BRAND_COLORS
 
 from ._version import __version__
+
+if TYPE_CHECKING:
+    from trustlens.trust_score import TrustScoreResult
 
 logger = logging.getLogger(__name__)
 
@@ -82,6 +85,7 @@ class TrustReport:
         embeddings: np.ndarray | None = None,
         framework: str | None = None,
         backend_metadata: dict[str, Any] | None = None,
+        task_type: str = "classification",
     ) -> None:
         self.results = results
         self.model = model
@@ -92,14 +96,40 @@ class TrustReport:
         self.embeddings = embeddings
         self.framework = framework
         self.backend_metadata = backend_metadata or {}
+        self.task_type = task_type
         self.metadata = self._build_metadata()
 
-        # Compute Trust Score immediately so it's always available
-        from trustlens.trust_score import compute_trust_score
-
-        self.trust_score = compute_trust_score(results)
         self._patterns: list[str] = []
-        self._compute_patterns()
+        if task_type == "regression":
+            # The Trust Score, patterns, and the deployment narrative are
+            # classification-oriented. A regression-specific trust score is a
+            # separate design (tracked as a follow-up), so it is intentionally
+            # not computed here — the regression report surfaces the raw
+            # reliability metrics via show()/to_dict() instead.
+            #
+            # It is None at runtime; every classification-only path (show,
+            # to_dict, save, summary_plot, deployment_explanation, …) is guarded
+            # by a task_type branch or _require_classification(), so the score
+            # is never dereferenced on a regression report. We cast rather than
+            # widen the attribute to Optional to keep the many classification
+            # consumers (and comparison.py) free of None-handling churn.
+            self.trust_score = cast("TrustScoreResult", None)
+        else:
+            # Compute Trust Score immediately so it's always available
+            from trustlens.trust_score import compute_trust_score
+
+            self.trust_score = compute_trust_score(results)
+            self._compute_patterns()
+
+    def _require_classification(self, feature: str) -> None:
+        """Guard classification-only features against regression reports."""
+        if self.task_type == "regression":
+            raise NotImplementedError(
+                f"{feature} is not available for regression reports yet. "
+                "Use report.show() / report.to_dict() for the regression "
+                "reliability metrics; visualizations and a regression trust "
+                "score are planned as follow-up phases."
+            )
 
     @property
     def patterns(self) -> list[str]:
@@ -153,6 +183,7 @@ class TrustReport:
     @property
     def deployment_explanation(self) -> dict[str, Any]:
         """Provide a structured explanation for the deployment verdict."""
+        self._require_classification("deployment_explanation")
         ts = self.trust_score
         grade_map = {"A": "PASS", "B": "CAUTION", "C": "CAUTION", "D": "BLOCK"}
         verdict = "BLOCK" if ts.is_blocked else grade_map.get(ts.grade, "PASS")
@@ -249,10 +280,17 @@ class TrustReport:
             "trustlens_version": __version__,
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "n_samples": int(len(self.y_true)),
-            "n_classes": int(len(np.unique(self.y_true))),
             "model_class": type(self.model).__name__ if self.model is not None else "Manual",
             "modules_run": list(self.results.keys()),
+            "task_type": self.task_type,
         }
+
+        # n_classes is a classification concept; for regression report the
+        # number of distinct target values instead.
+        if self.task_type == "regression":
+            meta["n_unique_targets"] = int(len(np.unique(self.y_true)))
+        else:
+            meta["n_classes"] = int(len(np.unique(self.y_true)))
 
         if self.framework:
             meta["framework"] = self.framework
@@ -295,7 +333,14 @@ class TrustReport:
 
         Displays the Trust Score prominently at the top, followed by
         key insights and then delimited per-module metric summaries.
+
+        For regression reports the classification Trust Score is not computed;
+        the regression reliability metrics are shown instead.
         """
+        if self.task_type == "regression":
+            self._show_regression(verbose=verbose)
+            return
+
         print("\nTrustLens Analysis Report")
         print(f"Timestamp : {self.metadata['timestamp']}")
         print(f"Model     : {self.metadata['model_class']}")
@@ -355,11 +400,99 @@ class TrustReport:
         self._print_score_methodology()
         print()
 
+    def _show_regression(self, verbose: bool = False) -> None:
+        """Render the regression reliability report (no classification trust score)."""
+        reg = self.results.get("regression", {})
+        print("\nTrustLens Regression Reliability Report")
+        print(f"Timestamp : {self.metadata['timestamp']}")
+        print(f"Model     : {self.metadata['model_class']}")
+        print(f"Samples   : {self.metadata['n_samples']:,}")
+        print("Task      : regression")
+
+        ed = reg.get("error_distribution", {})
+        if ed and ed.get("status") != "skipped":
+            print("\nError Distribution (|y_true - y_pred|):")
+            print(f"  MAE                : {ed.get('mean_absolute_error'):.4f}")
+            print(f"  RMSE               : {ed.get('rmse'):.4f}")
+            print(f"  Median abs error   : {ed.get('median_absolute_error'):.4f}")
+            print(f"  90th-pct abs error : {ed.get('p90_absolute_error'):.4f}")
+            print(f"  Max abs error      : {ed.get('max_error'):.4f}")
+            medae = ed.get("median_absolute_error") or 0.0
+            p90 = ed.get("p90_absolute_error") or 0.0
+            if medae > 0 and p90 / medae > 3:
+                print(
+                    f"  ! Heavy error tail : p90 is {p90 / medae:.1f}x the median "
+                    "— a tail of large mistakes worth investigating."
+                )
+
+        pic = reg.get("interval_coverage", {})
+        if pic:
+            print("\nPrediction Interval Coverage (PICP):")
+            if pic.get("status") == "skipped":
+                print(f"  skipped — {pic.get('details', pic.get('reason', 'no intervals'))}")
+            else:
+                print(
+                    f"  Coverage (PICP)    : {pic.get('picp'):.4f}  "
+                    f"(target {pic.get('target_coverage')})"
+                )
+                print(f"  Calibration error  : {pic.get('calibration_error'):+.4f}")
+                print(f"  Mean interval width: {pic.get('mean_interval_width'):.4f}")
+                print(f"  Verdict            : {pic.get('verdict')}")
+
+        evc = reg.get("error_variance_correlation", {})
+        if evc:
+            print("\nError-Uncertainty Correlation:")
+            if evc.get("status") == "skipped":
+                print(f"  skipped — {evc.get('details', evc.get('reason', 'no variance'))}")
+            else:
+                print(f"  Pearson            : {evc.get('pearson'):+.4f}")
+                print(f"  Spearman           : {evc.get('spearman'):+.4f}")
+                print(f"  Verdict            : {evc.get('verdict')}")
+
+        # Render any additional / plugin modules generically.
+        for module_name, module_data in self.results.items():
+            if module_name == "regression":
+                continue
+            import io
+            from contextlib import redirect_stdout
+
+            f = io.StringIO()
+            with redirect_stdout(f):
+                self._print_module(module_data, indent=0, verbose=verbose)
+            out = f.getvalue().strip()
+            if out:
+                print(f"\n{module_name.title()} Analysis")
+                print(out)
+
+        if (
+            pic.get("status") == "skipped"
+            and evc.get("status") == "skipped"
+        ):
+            print(
+                "\nNote: uncertainty metrics (PICP, error-variance correlation) need "
+                "prediction intervals / predicted variance. Pass prediction_intervals "
+                "and/or predicted_variance to analyze() to enable them."
+            )
+        print()
+
+    def _generate_regression_text(self, verbose: bool = False) -> str:
+        """Plain-text regression report (captures _show_regression's output)."""
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            self._show_regression(verbose=verbose)
+        return f.getvalue().strip()
+
     def _generate_text_report(self, verbose: bool = False) -> str:
         """
         Generate a clean, human-readable text report without ANSI colors.
         Mirroring the structure of show().
         """
+        if self.task_type == "regression":
+            return self._generate_regression_text(verbose=verbose)
+
         lines = []
         lines.append("TrustLens Analysis Report")
         lines.append(f"Timestamp : {self.metadata['timestamp']}")
@@ -724,6 +857,7 @@ class TrustReport:
         -------
         matplotlib.figure.Figure
         """
+        self._require_classification("summary_plot()")
         from trustlens.visualization.summary_plot import plot_summary_dashboard
 
         fig = plot_summary_dashboard(
@@ -791,6 +925,7 @@ class TrustReport:
         >>> report.show_failures(top_k=10)
         >>> report.show_failures(top_k=5, images=X_images)
         """
+        self._require_classification("show_failures()")
         max_conf = self._max_confidence()
         y_true = np.asarray(self.y_true)
         y_pred = np.asarray(self.y_pred)
@@ -877,6 +1012,7 @@ class TrustReport:
         save_dir : str, optional
           Directory path where figures are saved as PNG files.
         """
+        self._require_classification("plot()")
         from trustlens.visualization import plot_module
 
         modules_to_plot = [module] if module else list(self.results.keys())
@@ -1071,6 +1207,7 @@ class TrustReport:
             If ``mode`` is invalid, ``"bias"`` is not present in
             ``self.results``, or the data is unusable.
         """
+        self._require_classification("plot_bias()")
         import matplotlib.pyplot as plt
 
         from trustlens.visualization import _plot_bias
@@ -1349,6 +1486,9 @@ class TrustReport:
 
         p = Path(path).resolve()
 
+        if self.task_type == "regression":
+            return self._save_regression(path, p)
+
         # 1. Single-file JSON export
         if path.lower().endswith(".json"):
             p.parent.mkdir(parents=True, exist_ok=True)
@@ -1424,6 +1564,34 @@ class TrustReport:
         logger.info("Report bundle saved to: %s", out_dir)
         return out_dir
 
+    def _save_regression(self, path: str, p: Path) -> Path:
+        """Save a regression report (results + metadata; no classification score)."""
+        if path.lower().endswith(".json"):
+            p.parent.mkdir(parents=True, exist_ok=True)
+            data = {
+                "results": self._to_serializable(self.results),
+                "metadata": self.metadata,
+                "task_type": "regression",
+            }
+            p.write_text(json.dumps(data, indent=2), encoding="utf-8")
+            logger.info("Regression report JSON saved to: %s", p)
+            return p
+        if path.lower().endswith(".txt"):
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(self._generate_text_report(), encoding="utf-8")
+            logger.info("Regression report TXT saved to: %s", p)
+            return p
+        out_dir = p
+        out_dir.mkdir(parents=True, exist_ok=True)
+        (out_dir / "report.json").write_text(
+            json.dumps(self._to_serializable(self.results), indent=2), encoding="utf-8"
+        )
+        (out_dir / "metadata.json").write_text(
+            json.dumps(self.metadata, indent=2), encoding="utf-8"
+        )
+        logger.info("Regression report bundle saved to: %s", out_dir)
+        return out_dir
+
     # ------------------------------------------------------------------
     # to_dict()
     # ------------------------------------------------------------------
@@ -1442,6 +1610,15 @@ class TrustReport:
         from trustlens.utils import flatten_dict
 
         flat = flatten_dict(self._to_serializable(self.results))
+
+        # Regression reports carry no classification Trust Score / sub-scores /
+        # deployment verdict — return the flattened reliability metrics + meta.
+        if self.task_type == "regression":
+            flat["task_type"] = "regression"
+            flat["framework"] = self.metadata.get("framework", "unknown")
+            flat["trustlens_version"] = self.metadata["trustlens_version"]
+            return flat
+
         flat["trust_score"] = self.trust_score.score
         flat["trust_grade"] = self.trust_score.grade
         flat["framework"] = self.metadata.get("framework", "unknown")
@@ -1481,6 +1658,13 @@ class TrustReport:
 
     def __repr__(self) -> str:
         modules_str = ", ".join(self.results.keys())
+        if self.task_type == "regression":
+            return (
+                f"TrustReport(task='regression', "
+                f"model={self.metadata['model_class']!r}, "
+                f"samples={self.metadata['n_samples']}, "
+                f"modules=[{modules_str}])"
+            )
         return (
             f"TrustReport(model={self.metadata['model_class']!r}, "
             f"score={self.trust_score.score}/100 [{self.trust_score.grade}], "
@@ -1488,8 +1672,24 @@ class TrustReport:
             f"modules=[{modules_str}])"
         )
 
+    def _repr_html_regression(self) -> str:
+        """Simple text-based HTML for regression reports (no Phase-2 plots yet)."""
+        import html as _html
+
+        body = _html.escape(self._generate_regression_text())
+        return (
+            '<div style="font-family: monospace; max-width: 760px; padding: 18px; '
+            'border: 1px solid #e0e0e0; border-radius: 12px; background:#fff;">'
+            f'<pre style="white-space: pre-wrap; margin:0;">{body}</pre>'
+            f'<div style="text-align:right; font-size:12px; color:#aaa; margin-top:10px;">'
+            f"Generated by TrustLens v{__version__}</div></div>"
+        )
+
     def _repr_html_(self) -> str:
         """Rich HTML representation for Jupyter notebooks."""
+        if self.task_type == "regression":
+            return self._repr_html_regression()
+
         import base64
         import io
 


### PR DESCRIPTION
Phase 1 of the regression follow-up to #141, in the ordering you outlined (pipeline/report first; visualization and a regression trust score as later phases).

## What's in this PR (your Phase-1 scope)
- **Detect regression targets + route through a regression path** — `analyze(..., task="auto"|"classification"|"regression")`. Auto-detection deliberately errs toward classification (only clearly-continuous float targets route to regression, so a discrete label set is never mis-routed). The regression path skips the classification backend (no class probabilities) and resolves point predictions from `y_pred` or `model.predict(X)`.
- **Surface the regression metrics in the report object** — a new `_run_regression_pipeline` mirrors the classification pipeline (metrics → results → report) and routes through the merged metrics (`error_distribution`, `prediction_interval_coverage` / PICP, `error_variance_correlation`), under `report.results["regression"]`. The two uncertainty metrics degrade gracefully to `status="skipped"` when `prediction_intervals` / `predicted_variance` aren't supplied.
- **Regression report rendering** — `report.show()` renders a dedicated regression reliability summary (error distribution + PICP + error–uncertainty correlation, with a heavy-tail hint).
- **Serialization** — `report.to_dict()` and `report.save()` (json / txt / bundle) handle regression.

## Architecture / scope
Followed the existing classification architecture (metrics → report container → rendering) and kept the regression logic isolated. `TrustReport` gains a `task_type`; for regression the classification **Trust Score is intentionally not computed** (the separate phase you flagged). Classification-only features (`summary_plot`, `plot`, `plot_bias`, `show_failures`, `deployment_explanation`) raise a clear `NotImplementedError` on a regression report rather than failing cryptically — they'll light up with the visualization / trust-score phases. The classification path is unchanged.

## Usage
```python
# point predictions only
report = analyze(model, X_val, y_val, task="regression")
report.show()

# with uncertainty -> enables PICP + error–variance correlation
report = analyze(model, X_val, y_val,
                 prediction_intervals=(lower, upper),
                 predicted_variance=variance,
                 task="regression")
```

## Tests / checks
- `tests/test_regression_pipeline.py` (10): routing, auto-detection, `show()`, `to_dict()`, `save()` round-trip, the `model.predict` path, uncertainty metrics populated/skipped, and the classification-only guards.
- Full suite green (355 passed); `ruff` clean; `mypy trustlens/ --follow-imports=skip` clean.

Happy to adjust naming/structure to your preference. Visualization (residual / error-distribution plots) is the natural next scoped PR. Refs #82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a regression task mode alongside classification.
  * Introduced automatic task routing that infers regression for continuous float targets under `task="auto"`.
  * Added regression-specific controls including prediction intervals and predicted variance (with corresponding reliability metrics).
  * Regression reports now render regression metrics without classification-only fields and outputs.

* **Tests**
  * Expanded regression pipeline and `TrustReport` coverage, including serialization/saving round-trips, shape handling, uncertainty metric behavior, and invalid task/value guards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->