### PR TITLE
feat(viz): regression residual + error-distribution plots (#82)

### DIFF
--- a/tests/test_regression_visualization.py
+++ b/tests/test_regression_visualization.py
@@ -55,11 +55,25 @@ class TestPlotResiduals:
         assert "Residuals" in _legend_labels(ax)
 
     def test_interval_band_added_when_supplied(self, reg_arrays):
+        from matplotlib.collections import PolyCollection
+
         _, y_true, y_pred = reg_arrays
         lo, hi = y_pred - 2.0, y_pred + 2.0
         fig = plot_residuals(y_true, y_pred, prediction_intervals=(lo, hi), show=False)
         ax = fig.axes[0]
         assert "Prediction interval" in _legend_labels(ax)
+        # The band must actually be drawn in residual space spanning ~[-2, +2]
+        # (lower - pred = -2, upper - pred = +2), not merely a legend entry.
+        bands = [c for c in ax.collections if isinstance(c, PolyCollection)]
+        assert bands, "expected a fill_between PolyCollection for the interval band"
+        ys = np.concatenate([p.vertices[:, 1] for p in bands[0].get_paths()])
+        assert ys.min() == pytest.approx(-2.0, abs=0.1)
+        assert ys.max() == pytest.approx(2.0, abs=0.1)
+
+    def test_malformed_intervals_raise(self, reg_arrays):
+        _, y_true, y_pred = reg_arrays
+        with pytest.raises(ValueError, match=r"\(lower, upper\)"):
+            plot_residuals(y_true, y_pred, prediction_intervals=(y_pred,), show=False)
 
     def test_no_band_without_intervals(self, reg_arrays):
         _, y_true, y_pred = reg_arrays

--- a/tests/test_regression_visualization.py
+++ b/tests/test_regression_visualization.py
@@ -1,0 +1,181 @@
+"""
+tests/test_regression_visualization.py.
+=======================================
+Tests for the regression visualization plotting functions and their TrustReport
+methods: residual analysis and error-distribution plots, the optional
+prediction-interval band, regression-only guards, and a no-display smoke test.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")  # headless: no display required for the test run
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+from trustlens import analyze
+from trustlens.report import TrustReport
+from trustlens.visualization.regression_plots import (
+    plot_error_distribution,
+    plot_residuals,
+)
+
+
+@pytest.fixture
+def reg_arrays():
+    rng = np.random.default_rng(0)
+    n = 200
+    X = rng.normal(size=(n, 3))
+    y_true = X @ np.array([1.5, -2.0, 0.7]) + rng.normal(scale=1.0, size=n)
+    y_pred = y_true + rng.normal(scale=1.0, size=n)
+    return X, y_true, y_pred
+
+
+def _legend_labels(ax) -> list[str]:
+    legend = ax.get_legend()
+    return [t.get_text() for t in legend.get_texts()] if legend is not None else []
+
+
+# --------------------------------------------------------------------------- #
+# Module-level functions
+# --------------------------------------------------------------------------- #
+class TestPlotResiduals:
+    def test_returns_figure_with_residual_axes(self, reg_arrays):
+        _, y_true, y_pred = reg_arrays
+        fig = plot_residuals(y_true, y_pred, show=False)
+        assert isinstance(fig, plt.Figure)
+        ax = fig.axes[0]
+        assert "Residual" in ax.get_ylabel()
+        assert "Predicted" in ax.get_xlabel()
+        # scatter cloud present
+        assert len(ax.collections) >= 1
+        assert "Residuals" in _legend_labels(ax)
+
+    def test_interval_band_added_when_supplied(self, reg_arrays):
+        _, y_true, y_pred = reg_arrays
+        lo, hi = y_pred - 2.0, y_pred + 2.0
+        fig = plot_residuals(y_true, y_pred, prediction_intervals=(lo, hi), show=False)
+        ax = fig.axes[0]
+        assert "Prediction interval" in _legend_labels(ax)
+
+    def test_no_band_without_intervals(self, reg_arrays):
+        _, y_true, y_pred = reg_arrays
+        fig = plot_residuals(y_true, y_pred, show=False)
+        assert "Prediction interval" not in _legend_labels(fig.axes[0])
+
+    def test_singleton_column_flattened(self, reg_arrays):
+        _, y_true, y_pred = reg_arrays
+        fig = plot_residuals(y_true.reshape(-1, 1), y_pred.reshape(-1, 1), show=False)
+        assert isinstance(fig, plt.Figure)
+
+    def test_shape_mismatch_raises(self):
+        with pytest.raises(ValueError, match="same shape"):
+            plot_residuals(np.zeros(5), np.zeros(6), show=False)
+
+    def test_empty_raises(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            plot_residuals(np.array([]), np.array([]), show=False)
+
+    def test_mismatched_interval_bounds_raise(self, reg_arrays):
+        _, y_true, y_pred = reg_arrays
+        with pytest.raises(ValueError, match="prediction_intervals"):
+            plot_residuals(y_true, y_pred, prediction_intervals=(y_pred[:-1], y_pred), show=False)
+
+
+class TestPlotErrorDistribution:
+    def test_returns_figure_with_error_axes(self, reg_arrays):
+        _, y_true, y_pred = reg_arrays
+        fig = plot_error_distribution(y_true, y_pred, show=False)
+        assert isinstance(fig, plt.Figure)
+        ax = fig.axes[0]
+        assert "Error" in ax.get_xlabel()
+        # histogram bars present
+        assert len(ax.patches) >= 1
+        # fitted-normal overlay + zero-error line present
+        assert len(ax.lines) >= 1
+
+    def test_normal_overlay_present_for_dispersed_errors(self, reg_arrays):
+        _, y_true, y_pred = reg_arrays
+        fig = plot_error_distribution(y_true, y_pred, show=False)
+        labels = _legend_labels(fig.axes[0])
+        assert any(lbl.startswith("Normal fit") for lbl in labels)
+
+    def test_zero_bins_raises(self, reg_arrays):
+        _, y_true, y_pred = reg_arrays
+        with pytest.raises(ValueError, match="bins must be >= 1"):
+            plot_error_distribution(y_true, y_pred, bins=0, show=False)
+
+    def test_shape_mismatch_raises(self):
+        with pytest.raises(ValueError, match="same shape"):
+            plot_error_distribution(np.zeros(5), np.zeros(6), show=False)
+
+
+# --------------------------------------------------------------------------- #
+# TrustReport methods
+# --------------------------------------------------------------------------- #
+class TestReportMethods:
+    def _reg_report(self, reg_arrays, with_intervals=False):
+        X, y_true, y_pred = reg_arrays
+        kwargs = {}
+        if with_intervals:
+            kwargs["prediction_intervals"] = (y_pred - 2.0, y_pred + 2.0)
+        return analyze(
+            model=None,
+            X=X,
+            y_true=y_true,
+            y_pred=y_pred,
+            task="regression",
+            verbose=False,
+            **kwargs,
+        )
+
+    def test_report_plot_residuals(self, reg_arrays):
+        rep = self._reg_report(reg_arrays)
+        assert isinstance(rep, TrustReport) and rep.task_type == "regression"
+        fig = rep.plot_residuals(show=False)
+        assert isinstance(fig, plt.Figure)
+
+    def test_report_plot_residuals_band_from_intervals(self, reg_arrays):
+        rep = self._reg_report(reg_arrays, with_intervals=True)
+        fig = rep.plot_residuals(show=False)
+        assert "Prediction interval" in _legend_labels(fig.axes[0])
+
+    def test_report_plot_error_distribution(self, reg_arrays):
+        rep = self._reg_report(reg_arrays)
+        fig = rep.plot_error_distribution(show=False)
+        assert isinstance(fig, plt.Figure)
+
+    def test_classification_report_guards_residuals(self, reg_arrays):
+        X, y_true, _ = reg_arrays
+        y_cls = (y_true > np.median(y_true)).astype(int)
+        yprob = np.column_stack([1 - y_cls, y_cls]).astype(float)
+        rep = analyze(
+            model=None,
+            X=X,
+            y_true=y_cls,
+            y_pred=y_cls,
+            y_prob=yprob,
+            task="classification",
+            verbose=False,
+        )
+        with pytest.raises(NotImplementedError):
+            rep.plot_residuals(show=False)
+        with pytest.raises(NotImplementedError):
+            rep.plot_error_distribution(show=False)
+
+
+def test_no_display_smoke(reg_arrays):
+    """Under the Agg backend, rendering with show=True must not raise."""
+    import warnings
+
+    _, y_true, y_pred = reg_arrays
+    with warnings.catch_warnings():
+        # Agg is non-interactive; plt.show() warns but must not raise.
+        warnings.simplefilter("ignore", UserWarning)
+        fig1 = plot_residuals(y_true, y_pred, show=True)
+        fig2 = plot_error_distribution(y_true, y_pred, show=True)
+    assert isinstance(fig1, plt.Figure)
+    assert isinstance(fig2, plt.Figure)

--- a/trustlens/core/pipeline.py
+++ b/trustlens/core/pipeline.py
@@ -384,5 +384,7 @@ def _run_regression_pipeline(
         framework=framework,
         backend_metadata=backend_metadata,
         task_type="regression",
+        prediction_intervals=((lower, upper) if lower is not None and upper is not None else None),
+        predicted_variance=variance,
     )
     return report

--- a/trustlens/report.py
+++ b/trustlens/report.py
@@ -88,6 +88,8 @@ class TrustReport:
         framework: str | None = None,
         backend_metadata: dict[str, Any] | None = None,
         task_type: str = "classification",
+        prediction_intervals: tuple[np.ndarray, np.ndarray] | None = None,
+        predicted_variance: np.ndarray | None = None,
     ) -> None:
         self.results = results
         self.model = model
@@ -99,6 +101,11 @@ class TrustReport:
         self.framework = framework
         self.backend_metadata = backend_metadata or {}
         self.task_type = task_type
+        # Regression uncertainty inputs, retained so the regression visualizations
+        # (e.g. the prediction-interval band in plot_residuals) are self-contained
+        # from the report. Both are None for classification reports.
+        self.prediction_intervals = prediction_intervals
+        self.predicted_variance = predicted_variance
         self.metadata = self._build_metadata()
 
         self._patterns: list[str] = []
@@ -128,10 +135,69 @@ class TrustReport:
         if self.task_type == "regression":
             raise NotImplementedError(
                 f"{feature} is not available for regression reports yet. "
-                "Use report.show() / report.to_dict() for the regression "
-                "reliability metrics; visualizations and a regression trust "
-                "score are planned as follow-up phases."
+                "Use report.plot_residuals() / report.plot_error_distribution() for "
+                "regression visualizations, or report.show() / report.to_dict() for the "
+                "reliability metrics; a regression trust score is planned as a follow-up phase."
             )
+
+    def _require_regression(self, feature: str) -> None:
+        """Guard regression-only features against classification reports."""
+        if self.task_type != "regression":
+            raise NotImplementedError(
+                f"{feature} is only available for regression reports (this report is "
+                f"'{self.task_type}'). Use report.plot() / report.summary_plot() for "
+                "classification visualizations."
+            )
+
+    def plot_residuals(
+        self,
+        *,
+        title: str = "Residuals vs. Predicted",
+        save_path: str | None = None,
+        show: bool = True,
+    ) -> Any:
+        """Residuals (``y_true - y_pred``) vs. predicted value, for spotting
+        heteroscedasticity and bias. Regression reports only.
+
+        If prediction intervals were supplied to :func:`analyze`, they are overlaid
+        as a band in residual space. See
+        :func:`trustlens.visualization.regression_plots.plot_residuals`.
+        """
+        self._require_regression("plot_residuals")
+        from trustlens.visualization.regression_plots import plot_residuals
+
+        return plot_residuals(
+            self.y_true,
+            self.y_pred,
+            prediction_intervals=self.prediction_intervals,
+            title=title,
+            save_path=save_path,
+            show=show,
+        )
+
+    def plot_error_distribution(
+        self,
+        *,
+        bins: int = 30,
+        title: str = "Error Distribution",
+        save_path: str | None = None,
+        show: bool = True,
+    ) -> Any:
+        """Histogram of signed errors (``y_true - y_pred``) against a fitted normal,
+        for spotting skew and heavy tails. Regression reports only. See
+        :func:`trustlens.visualization.regression_plots.plot_error_distribution`.
+        """
+        self._require_regression("plot_error_distribution")
+        from trustlens.visualization.regression_plots import plot_error_distribution
+
+        return plot_error_distribution(
+            self.y_true,
+            self.y_pred,
+            bins=bins,
+            title=title,
+            save_path=save_path,
+            show=show,
+        )
 
     @property
     def patterns(self) -> list[str]:

--- a/trustlens/visualization/regression_plots.py
+++ b/trustlens/visualization/regression_plots.py
@@ -1,0 +1,302 @@
+"""
+trustlens.visualization.regression_plots.
+=========================================
+Diagnostic plots for the regression reliability path.
+
+Two complementary views of a regression model's errors:
+
+* :func:`plot_residuals` — residuals (``y_true - y_pred``) against the predicted
+  value. This is the canonical way to spot **heteroscedasticity** (a fan or curve
+  in the residual cloud) and **systematic bias** (the cloud drifting off the zero
+  line). An optional prediction-interval band can be overlaid.
+* :func:`plot_error_distribution` — a histogram of the signed errors against a
+  fitted-normal reference, so **skew** and **heavy tails** are visible at a glance.
+
+Both mirror the conventions of the classification plot modules: brand styling via
+:func:`trustlens.visualization.style.apply_style`, an explicit ``save_path`` /
+``show`` contract, and a returned :class:`matplotlib.figure.Figure`.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from trustlens.visualization.style import apply_style
+
+
+def _as_1d(name: str, values: np.ndarray) -> np.ndarray:
+    """Coerce to a 1-D float array, flattening a singleton ``(n, 1)`` column and
+    rejecting a true multi-output shape with a clear error."""
+    arr = np.asarray(values, dtype=float)
+    if arr.ndim == 2 and arr.shape[1] == 1:
+        arr = arr[:, 0]
+    if arr.ndim != 1:
+        raise ValueError(f"{name} must be 1-D, got shape {arr.shape}.")
+    return cast(np.ndarray, arr)
+
+
+def plot_residuals(
+    y_true: np.ndarray,
+    y_pred: np.ndarray,
+    *,
+    prediction_intervals: tuple[np.ndarray, np.ndarray] | None = None,
+    title: str = "Residuals vs. Predicted",
+    save_path: str | None = None,
+    show: bool = True,
+) -> plt.Figure:
+    """
+    Plot residuals (``y_true - y_pred``) against the predicted value.
+
+    The plot shows:
+
+    * **Residual scatter** — one point per observation; a horizontal, evenly
+      spread band around zero indicates well-behaved errors.
+    * **Zero-error reference** — a dashed line at ``residual = 0``.
+    * **Optional prediction-interval band** — when ``prediction_intervals`` is
+      supplied, the interval width is shown in residual space (``lower - pred`` to
+      ``upper - pred``), so you can read off whether the band actually brackets the
+      residual cloud.
+    * **Diagnostics annotation** — mean residual (bias) and the correlation between
+      ``|residual|`` and the prediction (a positive value flags heteroscedasticity).
+
+    Parameters
+    ----------
+    y_true : np.ndarray
+        Observed target values, shape ``(n,)`` (a singleton ``(n, 1)`` is accepted).
+    y_pred : np.ndarray
+        Point predictions, same shape as ``y_true``.
+    prediction_intervals : tuple[np.ndarray, np.ndarray], optional
+        ``(lower, upper)`` per-observation interval bounds. When given, the band is
+        overlaid in residual space.
+    title : str
+        Figure title.
+    save_path : str, optional
+        If given, the figure is written to this path.
+    show : bool
+        Whether to call ``plt.show()``.
+
+    Returns
+    -------
+    matplotlib.figure.Figure
+
+    Raises
+    ------
+    ValueError
+        When ``y_true``/``y_pred`` are empty or their shapes disagree.
+    """
+    yt = _as_1d("y_true", y_true)
+    yp = _as_1d("y_pred", y_pred)
+    if yt.shape != yp.shape:
+        raise ValueError(
+            f"y_true and y_pred must have the same shape, got {yt.shape} vs {yp.shape}."
+        )
+    if yt.size == 0:
+        raise ValueError("y_true and y_pred must be non-empty.")
+
+    residuals = yt - yp
+    bias = float(np.mean(residuals))
+    # Heteroscedasticity signal: correlation of |residual| with the prediction.
+    if yt.size >= 2 and np.std(yp) > 0 and np.std(np.abs(residuals)) > 0:
+        hetero = float(np.corrcoef(yp, np.abs(residuals))[0, 1])
+    else:
+        hetero = float("nan")
+
+    with apply_style() as theme:
+        blue = theme.brand["blue"]
+        gray = theme.brand["muted_gray"]
+        neutral = theme.semantic["neutral"]
+
+        fig, ax = plt.subplots(figsize=(7, 5), constrained_layout=True)
+
+        if prediction_intervals is not None:
+            lower = _as_1d("prediction_intervals[0]", prediction_intervals[0])
+            upper = _as_1d("prediction_intervals[1]", prediction_intervals[1])
+            if lower.shape != yp.shape or upper.shape != yp.shape:
+                raise ValueError(
+                    "prediction_intervals bounds must match y_pred's shape, got "
+                    f"{lower.shape} / {upper.shape} vs {yp.shape}."
+                )
+            order = np.argsort(yp)
+            ax.fill_between(
+                yp[order],
+                (lower - yp)[order],
+                (upper - yp)[order],
+                alpha=0.15,
+                color=blue,
+                label="Prediction interval",
+            )
+
+        ax.scatter(
+            yp,
+            residuals,
+            s=18,
+            alpha=0.6,
+            color=blue,
+            edgecolor=neutral["edge"],
+            linewidth=0.3,
+            label="Residuals",
+        )
+        ax.axhline(0, color=gray, lw=1.5, linestyle="--", label="Zero error")
+
+        annotation_lines = [f"bias  = {bias:.4g}"]
+        if not np.isnan(hetero):
+            annotation_lines.append(f"corr(|r|, ŷ) = {hetero:+.3f}")
+        ax.text(
+            0.04,
+            0.96,
+            "\n".join(annotation_lines),
+            transform=ax.transAxes,
+            fontsize=11,
+            verticalalignment="top",
+            bbox=dict(
+                boxstyle="round,pad=0.4",
+                facecolor=neutral["annotation_face"],
+                edgecolor=neutral["annotation_edge"],
+                alpha=0.9,
+            ),
+            fontfamily="monospace",
+        )
+
+        ax.set_xlabel("Predicted value", fontsize=12)
+        ax.set_ylabel("Residual (true − predicted)", fontsize=12)
+        ax.set_title(title, fontsize=14, fontweight="bold", pad=10)
+        ax.legend(loc="best", fontsize=10)
+        ax.grid(True, alpha=theme.grid["alpha"])
+
+        if save_path:
+            fig.savefig(save_path, dpi=theme.fig_defaults["savefig_dpi"], bbox_inches="tight")
+
+        if show:
+            plt.show()
+
+        plt.close(fig)
+        return fig
+
+
+def plot_error_distribution(
+    y_true: np.ndarray,
+    y_pred: np.ndarray,
+    *,
+    bins: int = 30,
+    title: str = "Error Distribution",
+    save_path: str | None = None,
+    show: bool = True,
+) -> plt.Figure:
+    """
+    Plot a histogram of signed errors (``y_true - y_pred``) against a fitted normal.
+
+    The plot shows:
+
+    * **Error histogram** — density of the signed errors.
+    * **Fitted-normal overlay** — a Gaussian with the errors' own mean and standard
+      deviation, so departures (skew, heavy tails, bimodality) are obvious.
+    * **Zero-error reference** — a dashed vertical line.
+    * **Metric annotation** — MAE and RMSE.
+
+    Parameters
+    ----------
+    y_true : np.ndarray
+        Observed target values, shape ``(n,)`` (a singleton ``(n, 1)`` is accepted).
+    y_pred : np.ndarray
+        Point predictions, same shape as ``y_true``.
+    bins : int
+        Number of histogram bins (must be >= 1).
+    title : str
+        Figure title.
+    save_path : str, optional
+        If given, the figure is written to this path.
+    show : bool
+        Whether to call ``plt.show()``.
+
+    Returns
+    -------
+    matplotlib.figure.Figure
+
+    Raises
+    ------
+    ValueError
+        When inputs are empty, shapes disagree, or ``bins < 1``.
+    """
+    if bins < 1:
+        raise ValueError(f"bins must be >= 1, got {bins}")
+
+    yt = _as_1d("y_true", y_true)
+    yp = _as_1d("y_pred", y_pred)
+    if yt.shape != yp.shape:
+        raise ValueError(
+            f"y_true and y_pred must have the same shape, got {yt.shape} vs {yp.shape}."
+        )
+    if yt.size == 0:
+        raise ValueError("y_true and y_pred must be non-empty.")
+
+    errors = yt - yp
+    mu = float(np.mean(errors))
+    sigma = float(np.std(errors))
+    mae = float(np.mean(np.abs(errors)))
+    rmse = float(np.sqrt(np.mean(errors**2)))
+
+    with apply_style() as theme:
+        blue = theme.brand["blue"]
+        orange = theme.brand["orange"]
+        gray = theme.brand["muted_gray"]
+        neutral = theme.semantic["neutral"]
+
+        fig, ax = plt.subplots(figsize=(7, 5), constrained_layout=True)
+
+        ax.hist(
+            errors,
+            bins=bins,
+            density=True,
+            color=blue,
+            alpha=0.7,
+            edgecolor=neutral["edge"],
+            linewidth=0.5,
+            label="Errors",
+        )
+
+        if sigma > 0:
+            xs = np.linspace(float(errors.min()), float(errors.max()), 200)
+            pdf = np.exp(-0.5 * ((xs - mu) / sigma) ** 2) / (sigma * np.sqrt(2.0 * np.pi))
+            ax.plot(
+                xs,
+                pdf,
+                color=orange,
+                lw=2.0,
+                label=f"Normal fit (μ={mu:.3g}, σ={sigma:.3g})",
+            )
+
+        ax.axvline(0, color=gray, lw=1.5, linestyle="--", label="Zero error")
+
+        ax.text(
+            0.04,
+            0.96,
+            f"MAE  = {mae:.4g}\nRMSE = {rmse:.4g}",
+            transform=ax.transAxes,
+            fontsize=11,
+            verticalalignment="top",
+            bbox=dict(
+                boxstyle="round,pad=0.4",
+                facecolor=neutral["annotation_face"],
+                edgecolor=neutral["annotation_edge"],
+                alpha=0.9,
+            ),
+            fontfamily="monospace",
+        )
+
+        ax.set_xlabel("Error (true − predicted)", fontsize=12)
+        ax.set_ylabel("Density", fontsize=12)
+        ax.set_title(title, fontsize=14, fontweight="bold", pad=10)
+        ax.legend(loc="best", fontsize=10)
+        ax.grid(True, alpha=theme.grid["alpha"])
+
+        if save_path:
+            fig.savefig(save_path, dpi=theme.fig_defaults["savefig_dpi"], bbox_inches="tight")
+
+        if show:
+            plt.show()
+
+        plt.close(fig)
+        return fig

--- a/trustlens/visualization/regression_plots.py
+++ b/trustlens/visualization/regression_plots.py
@@ -112,8 +112,14 @@ def plot_residuals(
         fig, ax = plt.subplots(figsize=(7, 5), constrained_layout=True)
 
         if prediction_intervals is not None:
-            lower = _as_1d("prediction_intervals[0]", prediction_intervals[0])
-            upper = _as_1d("prediction_intervals[1]", prediction_intervals[1])
+            try:
+                lower_raw, upper_raw = prediction_intervals
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    "prediction_intervals must be a (lower, upper) pair of arrays."
+                ) from exc
+            lower = _as_1d("prediction_intervals[0]", lower_raw)
+            upper = _as_1d("prediction_intervals[1]", upper_raw)
             if lower.shape != yp.shape or upper.shape != yp.shape:
                 raise ValueError(
                     "prediction_intervals bounds must match y_pred's shape, got "


### PR DESCRIPTION
## Regression visualizations (phase 3 of #82)

Follows the merged metrics (#141) and pipeline/report integration (#142). Implements the two visualizations from the #82 checklist, as agreed in #142.

### What's added

**`trustlens/visualization/regression_plots.py`**
- `plot_residuals(y_true, y_pred, prediction_intervals=None, …)` — residuals (`y_true − y_pred`) vs. predicted value: the canonical view for **heteroscedasticity** (a fan/curve in the cloud) and **bias** (the cloud drifting off zero). Includes a dashed zero-error reference, an optional **prediction-interval band** drawn in residual space (`lower − pred` to `upper − pred`), and a `bias` / `corr(|residual|, ŷ)` annotation.
- `plot_error_distribution(y_true, y_pred, …)` — signed-error histogram with a **fitted-normal overlay** (so skew / heavy tails are obvious) and an MAE/RMSE annotation.

Both follow the existing plot-module conventions: `apply_style()` theming, the `save_path` / `show` contract, and a returned `matplotlib.figure.Figure`. `matplotlib` stays lazily imported by the report (the module itself is imported inside the report methods, as the other viz modules are).

**`TrustReport` methods**
- `TrustReport.plot_residuals()` / `.plot_error_distribution()`, guarded by a new `_require_regression()` — the mirror of the existing `_require_classification()`; calling them on a classification report raises `NotImplementedError`. The classification guard message now points at these new plots.
- The report now retains `prediction_intervals` / `predicted_variance` (optional, `None` for classification) so the interval band is available end-to-end from `report.plot_residuals()`; wired through the regression pipeline. Backward-compatible (new constructor params default to `None`).

### Tests
`tests/test_regression_visualization.py` (16): figure/axes assertions, the interval band (present only when supplied), validation errors (shape mismatch, empty, `bins < 1`, mismatched bounds), `TrustReport` method integration, the classification guard, and a no-display (Agg) smoke test. Full suite **358 → 374**, all green; `ruff check`, `ruff format --check .`, and `mypy trustlens/ --follow-imports=skip` clean.

Scoped as a dedicated PR, separate from the regression trust score (which, as discussed, needs its own design pass on weighting/thresholds). Closing notes / screenshots happy to add if useful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added residuals and error-distribution visualization methods to regression reports.
  * Regression reports now optionally display prediction-interval uncertainty as bands on residuals.
  * Regression reports now store and surface prediction uncertainty details for later use.

* **Tests**
  * Added/updated headless regression-visualization tests to validate figure outputs, labels/legend entries, interval-band rendering, and input validation.
  * Added smoke coverage to ensure plots can be generated without display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->