### PR TITLE
feat(regression): persist Var(y) to recompute Trust Score from stored reports (#150)

### DIFF
--- a/tests/test_regression_trust_score.py
+++ b/tests/test_regression_trust_score.py
@@ -16,6 +16,8 @@ Covers the converged v1 spec:
 
 from __future__ import annotations
 
+import warnings
+
 import numpy as np
 import pytest
 
@@ -322,3 +324,67 @@ def test_constant_target_imperfect_fit_zero_skill_not_blocked():
     assert not r.is_blocked  # skill 0.0 is not < 0 → not a blocker
     assert r.sub_scores["accuracy"] == pytest.approx(0.0)
     assert r.grade == "D"
+
+
+# ---------------------------------------------------------------------------
+# Persisted target_variance — recompute a regression Trust Score from a stored
+# report without the original y_true (issue #150)
+# ---------------------------------------------------------------------------
+
+
+def test_stored_variance_recompute_equals_y_true():
+    """A score recomputed from a persisted target_variance is identical to the
+    score computed from y_true."""
+    res = _results(_ed(0.9), _cov(0.0), _corr(0.9))
+    from_y_true = regression_trust_score(res, Y)
+    res["regression"]["target_variance"] = VAR_Y  # what the pipeline persists
+    from_stored = regression_trust_score(res)  # no y_true in memory
+    assert from_stored.score == from_y_true.score
+    assert from_stored.grade == from_y_true.grade
+    assert from_stored.sub_scores == from_y_true.sub_scores
+    assert from_stored.breakdown == from_y_true.breakdown
+
+
+def test_missing_both_y_true_and_stored_variance_raises():
+    """Neither y_true nor a persisted variance → explicit error, never a silent
+    0.0 that would masquerade as a constant target."""
+    res = _results(_ed(0.9))  # no target_variance persisted
+    with pytest.raises(ValueError, match="target variance"):
+        regression_trust_score(res)  # and no y_true
+
+
+def test_stored_zero_variance_is_honoured_not_treated_as_missing():
+    """A genuine constant target persists as target_variance == 0.0 and must be
+    used (constant-target branch), not rejected as 'missing'."""
+    ed = _ed(0.0)
+    ed["rmse"] = 0.0  # perfect fit on a constant target
+    res = {
+        "regression": {
+            "error_distribution": ed,
+            "interval_coverage": _cov_skipped(),
+            "error_variance_correlation": _corr_skipped(),
+            "target_variance": 0.0,
+        }
+    }
+    r = regression_trust_score(res)  # no y_true; 0.0 must be used, not rejected
+    assert r.task_type == "regression"
+    assert r.sub_scores["accuracy"] == pytest.approx(100.0)  # perfect constant-target fit
+
+
+def test_y_true_wins_and_warns_on_mismatch_with_stored():
+    """When both are present and disagree, y_true wins and a warning fires."""
+    res = _results(_ed(0.9), _cov(0.0), _corr(0.9))
+    res["regression"]["target_variance"] = VAR_Y * 4.0  # deliberately wrong
+    with pytest.warns(UserWarning, match="disagrees with the persisted"):
+        mismatched = regression_trust_score(res, Y)
+    clean = regression_trust_score(_results(_ed(0.9), _cov(0.0), _corr(0.9)), Y)
+    assert mismatched.score == clean.score  # y_true wins → stored value ignored
+
+
+def test_matching_stored_variance_does_not_warn():
+    """A persisted variance equal to Var(y_true) must not warn."""
+    res = _results(_ed(0.9), _cov(0.0), _corr(0.9))
+    res["regression"]["target_variance"] = VAR_Y
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any warning becomes a test failure
+        regression_trust_score(res, Y)

--- a/trustlens/core/pipeline.py
+++ b/trustlens/core/pipeline.py
@@ -365,6 +365,10 @@ def _run_regression_pipeline(
             y_true, lower, upper, confidence_level=confidence_level
         ),
         "error_variance_correlation": error_variance_correlation(y_true, y_pred, variance),
+        # Persist Var(y) (population variance, ddof=0 — identical to the on-the-fly
+        # computation in regression_trust_score) so the regression Trust Score can
+        # be recomputed from a stored report without the original y_true (issue #150).
+        "target_variance": float(np.var(np.asarray(y_true, dtype=float))),
     }
 
     results: dict[str, Any] = {"regression": regression_results}

--- a/trustlens/core/pipeline.py
+++ b/trustlens/core/pipeline.py
@@ -372,9 +372,7 @@ def _run_regression_pipeline(
         # would corrupt a downstream recompute — fall back to 0.0 (the same value the
         # read path assigns an empty y_true, routing through the constant-target branch).
         "target_variance": (
-            float(np.var(np.asarray(y_true, dtype=float)))
-            if np.asarray(y_true).size
-            else 0.0
+            float(np.var(np.asarray(y_true, dtype=float))) if np.asarray(y_true).size else 0.0
         ),
     }
 

--- a/trustlens/core/pipeline.py
+++ b/trustlens/core/pipeline.py
@@ -368,7 +368,14 @@ def _run_regression_pipeline(
         # Persist Var(y) (population variance, ddof=0 — identical to the on-the-fly
         # computation in regression_trust_score) so the regression Trust Score can
         # be recomputed from a stored report without the original y_true (issue #150).
-        "target_variance": float(np.var(np.asarray(y_true, dtype=float))),
+        # Guard the empty case: np.var([]) is NaN, which is not JSON-serializable and
+        # would corrupt a downstream recompute — fall back to 0.0 (the same value the
+        # read path assigns an empty y_true, routing through the constant-target branch).
+        "target_variance": (
+            float(np.var(np.asarray(y_true, dtype=float)))
+            if np.asarray(y_true).size
+            else 0.0
+        ),
     }
 
     results: dict[str, Any] = {"regression": regression_results}

--- a/trustlens/trust_score.py
+++ b/trustlens/trust_score.py
@@ -76,6 +76,7 @@ References
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass, field
 
 import numpy as np
@@ -581,6 +582,9 @@ def _regression_accuracy_score(error_dist: dict, target_variance: float) -> dict
     else:
         # Constant target: a mean-predictor is already exact, so skill "over the
         # mean" is undefined. Treat a perfect fit as full skill, else none.
+        # NB: a 0.0 here unambiguously means a genuine constant target — callers
+        # resolve a *missing* variance to a ValueError upstream, never to 0.0
+        # (issue #150), so this branch is never reached for absent ground truth.
         skill = 1.0 if mse <= 1e-12 else 0.0
 
     base = 100.0 * float(np.clip(skill, 0.0, 1.0))
@@ -635,7 +639,7 @@ def _reg_metric_present(metric: dict | None) -> bool:
 
 def regression_trust_score(
     results: dict,
-    y_true: np.ndarray,
+    y_true: np.ndarray | None = None,
     weights: dict[str, float] | None = None,
 ) -> TrustScoreResult:
     """
@@ -655,8 +659,14 @@ def regression_trust_score(
       Expected keys: ``error_distribution`` (always present) plus the optional
       ``interval_coverage`` / ``error_variance_correlation`` (which may be
       ``status="skipped"`` dicts when their inputs were absent).
-    y_true : np.ndarray
-      Ground-truth targets, used to compute ``Var(y)`` for the skill score.
+    y_true : np.ndarray, optional
+      Ground-truth targets, used to compute ``Var(y)`` for the skill score. May
+      be omitted **only** when ``results`` carries a persisted
+      ``regression["target_variance"]`` (as emitted by the regression pipeline,
+      issue #150), which is then used as the fallback so a regression Trust Score
+      can be recomputed from a stored report alone. If both are supplied, the
+      explicitly-passed ``y_true`` wins and a mismatch beyond tolerance warns. If
+      neither is available a ``ValueError`` is raised.
     weights : dict, optional
       Custom dimension weights (keys: ``"accuracy"``, ``"interval_calibration"``,
       ``"uncertainty_informativeness"``). Defaults to ``0.30 / 0.40 / 0.30``.
@@ -678,8 +688,34 @@ def regression_trust_score(
     coverage = reg.get("interval_coverage", {})
     corr = reg.get("error_variance_correlation", {})
 
-    y_true_arr = np.asarray(y_true, dtype=float)
-    target_variance = float(np.var(y_true_arr)) if y_true_arr.size else 0.0
+    # Resolve Var(y) for the skill denominator. Priority (issue #150):
+    #   1. explicit y_true → np.var (population, ddof=0), no behaviour change;
+    #   2. else a persisted results["regression"]["target_variance"];
+    #   3. else raise — never silently fall through to 0.0, which would route a
+    #      missing variance through the genuine "constant target" branch and
+    #      yield a misleading skill score.
+    stored_variance = reg.get("target_variance")
+    if y_true is not None:
+        y_true_arr = np.asarray(y_true, dtype=float)
+        target_variance = float(np.var(y_true_arr)) if y_true_arr.size else 0.0
+        if stored_variance is not None and not np.isclose(
+            target_variance, float(stored_variance), rtol=1e-6, atol=1e-9
+        ):
+            warnings.warn(
+                "regression_trust_score: Var(y) from the supplied y_true "
+                f"({target_variance:.6g}) disagrees with the persisted "
+                f"target_variance ({float(stored_variance):.6g}); using y_true.",
+                stacklevel=2,
+            )
+    elif stored_variance is not None:
+        target_variance = float(stored_variance)
+    else:
+        raise ValueError(
+            "regression_trust_score needs the target variance Var(y) to compute "
+            "the skill score, but neither was available: pass y_true, or use a "
+            "report whose regression results carry a persisted 'target_variance' "
+            "(emitted by the regression pipeline; see issue #150)."
+        )
 
     w = dict(_REGRESSION_DEFAULT_WEIGHTS)
     if weights:


### PR DESCRIPTION
Closes #150. Follow-up to the regression Trust Score (RFC #145, implemented in #147).

Persists the target variance so `regression_trust_score(...)` can be recomputed from a **stored** report (JSON artifact, dashboard, CI artifact, audit log) without the original `y_true` in memory — `Var(y)` was the one missing scalar.

### What changed (per the placement/decisions you confirmed on #150)

- **Write path** (`core/pipeline.py`): emit a top-level `results["regression"]["target_variance"] = float(np.var(np.asarray(y_true)))` — population variance, `ddof=0`, byte-identical to the on-the-fly computation, so a recompute-from-stored score equals the in-memory one.
- **Read path** (`trust_score.py::regression_trust_score`): `y_true` is now **optional**; `Var(y)` resolves in priority order
  1. explicit `y_true` → `np.var` (no behaviour change),
  2. else persisted `target_variance`,
  3. else **`ValueError`** — never a silent `0.0` (which would route through the genuine constant-target branch and yield a misleading skill score).
  When both are present, the explicit `y_true` wins and a mismatch beyond tolerance emits a `UserWarning`.
- `_regression_accuracy_score`: doc note that `0.0` now unambiguously means a genuine constant target (missing variance is a `ValueError` upstream, never `0.0`).

### Compatibility
- Additive, optional field; older stored reports keep working as long as `y_true` is passed. The signature stays source-compatible (`y_true` only becomes optional). Serialization is unchanged — the float rides the existing `_to_serializable` path and round-trips in JSON automatically.

### Tests (all green locally)
`tests/test_regression_trust_score.py` adds: recompute-from-stored equals recompute-from-`y_true` (score/grade/sub-scores/breakdown); missing-both raises `ValueError`; a stored `Var(y)=0` constant target is honoured (not treated as missing); mismatch warns and `y_true` wins; a matching stored value does not warn. Full local run: `test_regression_trust_score`, `test_regression_pipeline`, `test_core_pipeline`, `test_regression`, `test_api`, `test_output_formatting`, `test_metrics_all_exports` — all pass (94 tests). End-to-end smoke confirms the field is emitted, survives a JSON round-trip, and recomputes to the same score with no `y_true`.

Happy to adjust placement/naming or the mismatch policy if you'd prefer a different convention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Regression Trust Score can now be computed without providing original target values when the report already includes stored target variance.
  * Regression results now carry stored target-variance metadata for reuse.
* **Bug Fixes**
  * Improved handling for missing/empty target values, avoiding invalid stored values.
  * Clear error is raised when neither original targets nor stored variance is available.
  * If provided targets conflict with stored variance, a warning is emitted (and the provided targets are used); no warning when they match.
* **Tests**
  * Added regression coverage for persisted variance recomputation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->