### PR TITLE
feat(visualization): add radar comparison

### DIFF
--- a/tests/test_comparison_visualization.py
+++ b/tests/test_comparison_visualization.py
@@ -19,7 +19,25 @@ class TestPlotComparisonDiagramValidation:
         with pytest.raises(ValueError, match="metrics_dict must not be empty"):
             plot_radar_comparison(empty_dict, save_path=None, show=False)
 
-    def test_radar(self):
+    def test_models_share_dimensions(self) -> None:
+        metrics_dict = {
+            "Random Forest": {
+                "calibration": 82.4,
+                "failure": 76.1,
+                "bias": 91.0,
+                "representation": 68.5,
+            },
+            "Logistic Regression": {
+                "diff_calibration": 71.2,
+                "diff_failure": 84.3,
+                "diff_bias": 88.5,
+                "diff_representation": 55.0,
+            },
+        }
+        with pytest.raises(ValueError, match="every model should use the same dimensions"):
+            plot_radar_comparison(metrics_dict, save_path=None, show=False)
+
+    def test_successful_figure_generation(self):
         metrics_dict = {
             "Random Forest": {
                 "calibration": 82.4,

--- a/tests/test_comparison_visualization.py
+++ b/tests/test_comparison_visualization.py
@@ -15,7 +15,7 @@ class TestPlotComparisonDiagramValidation:
     """Validate input checks for plot_radar_comparison."""
 
     def test_empty_data(self) -> None:
-        empty_dict = {}
+        empty_dict: dict[str, dict[str, float]] = {}
         with pytest.raises(ValueError, match="metrics_dict must not be empty"):
             plot_radar_comparison(empty_dict, save_path=None, show=False)
 
@@ -37,7 +37,7 @@ class TestPlotComparisonDiagramValidation:
         with pytest.raises(ValueError, match="every model should use the same dimensions"):
             plot_radar_comparison(metrics_dict, save_path=None, show=False)
 
-    def test_successful_figure_generation(self):
+    def test_successful_figure_generation(self) -> None:
         metrics_dict = {
             "Random Forest": {
                 "calibration": 82.4,

--- a/tests/test_comparison_visualization.py
+++ b/tests/test_comparison_visualization.py
@@ -1,0 +1,38 @@
+"""
+tests/test_comparison_visualization.py.
+========================================
+Tests for the comparison visualization plotting functions.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from trustlens.visualization.comparison_plots import plot_radar_comparison
+
+
+class TestPlotComparisonDiagramValidation:
+    """Validate input checks for plot_radar_comparison."""
+
+    def test_empty_data(self) -> None:
+        empty_dict = {}
+        with pytest.raises(ValueError, match="metrics_dict must not be empty"):
+            plot_radar_comparison(empty_dict, save_path=None, show=False)
+
+    def test_radar(self):
+        metrics_dict = {
+            "Random Forest": {
+                "calibration": 82.4,
+                "failure": 76.1,
+                "bias": 91.0,
+                "representation": 68.5,
+            },
+            "Logistic Regression": {
+                "calibration": 71.2,
+                "failure": 84.3,
+                "bias": 88.5,
+                "representation": 55.0,
+            },
+        }
+        fig = plot_radar_comparison(metrics_dict, save_path=None, show=False)
+        assert fig is not None

--- a/trustlens/visualization/comparison_plots.py
+++ b/trustlens/visualization/comparison_plots.py
@@ -14,6 +14,35 @@ def plot_radar_comparison(
     save_path: str | None = None,
     show: bool = True,
 ) -> plt.Figure:
+    """
+    Plot a radar chart comparing dimensions across multiple models.
+
+    Each model is drawn as a filled polygon on a polar axis. Axes correspond
+    to metric names (e.g., calibration, failure, bias) and values are scores.
+
+    Parameters
+    ----------
+    metrics_dict : dict[str, dict[str, float]]
+      Mapping of model name to metric scores, e.g.
+      ``{"Random Forest": {"calibration": 82.4, "failure": 76.1}}``.
+      All models should share the same metric keys; axis labels are taken
+      from the first model entry.
+    title : str
+      Plot title.
+    save_path : str, optional
+      If provided, saves the figure to this path.
+    show : bool
+      If True, calls ``plt.show()`` on interactive backends.
+
+    Returns
+    -------
+    matplotlib.figure.Figure
+
+    Raises
+    ------
+    ValueError
+        When ``metrics_dict`` is empty.
+    """
     if not metrics_dict:
         raise ValueError("metrics_dict must not be empty")
 

--- a/trustlens/visualization/comparison_plots.py
+++ b/trustlens/visualization/comparison_plots.py
@@ -71,7 +71,7 @@ def plot_radar_comparison(
             constrained_layout=True,
         )
 
-        colors = get_categorical_colors(len(metrics_dict), theme=theme)
+        colors = get_categorical_colors(len(metrics_dict))
 
         for (model_name, scores), color in zip(metrics_dict.items(), colors):
             values = [scores[label] for label in dimensions]

--- a/trustlens/visualization/comparison_plots.py
+++ b/trustlens/visualization/comparison_plots.py
@@ -8,6 +8,14 @@ import numpy as np
 from trustlens.visualization.style import apply_style, get_categorical_colors
 
 
+def _get_shared_dimensions(metrics_dict: dict[str, dict[str, float]]) -> list[str] | None:
+    ref = list(next(iter(metrics_dict.values())).keys())
+    for model in metrics_dict.values():
+        if list(model.keys()) != ref:
+            return None
+    return ref
+
+
 def plot_radar_comparison(
     metrics_dict: dict[str, dict[str, float]],
     title: str = "Model Comparison",
@@ -25,8 +33,8 @@ def plot_radar_comparison(
     metrics_dict : dict[str, dict[str, float]]
       Mapping of model name to metric scores, e.g.
       ``{"Random Forest": {"calibration": 82.4, "failure": 76.1}}``.
-      All models should share the same metric keys; axis labels are taken
-      from the first model entry.
+      Every model must use the same metric keys in the same order; axis
+      labels are taken from the first model entry.
     title : str
       Plot title.
     save_path : str, optional
@@ -41,13 +49,19 @@ def plot_radar_comparison(
     Raises
     ------
     ValueError
-        When ``metrics_dict`` is empty.
+        If ``metrics_dict`` is empty.
+    ValueError
+        If any model uses different metric keys or key order than the first
+        model entry.
     """
     if not metrics_dict:
         raise ValueError("metrics_dict must not be empty")
 
-    labels = list(next(iter(metrics_dict.values())).keys())
-    angles = np.linspace(0, 2 * np.pi, len(labels), endpoint=False)
+    dimensions = _get_shared_dimensions(metrics_dict)
+    if dimensions is None:
+        raise ValueError("every model should use the same dimensions")
+
+    angles = np.linspace(0, 2 * np.pi, len(dimensions), endpoint=False)
     angles = np.concatenate([angles, angles[:1]])
 
     with apply_style() as theme:
@@ -60,14 +74,14 @@ def plot_radar_comparison(
         colors = get_categorical_colors(len(metrics_dict), theme=theme)
 
         for (model_name, scores), color in zip(metrics_dict.items(), colors):
-            values = [scores[label] for label in labels]
+            values = [scores[label] for label in dimensions]
             values = values + values[:1]
 
             ax.plot(angles, values, color=color, label=model_name, linewidth=2)
             ax.fill(angles, values, color=color, alpha=0.2)
 
         ax.set_xticks(angles[:-1])
-        ax.set_xticklabels(labels)
+        ax.set_xticklabels(dimensions)
         ax.set_title(title, fontweight="bold")
         ax.grid(True, alpha=theme.grid["alpha"])
         ax.legend(loc="upper right", bbox_to_anchor=(1.2, 1.1))

--- a/trustlens/visualization/comparison_plots.py
+++ b/trustlens/visualization/comparison_plots.py
@@ -1,0 +1,52 @@
+"""Multi-model radar comparison plots."""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from trustlens.visualization.style import apply_style, get_categorical_colors
+
+
+def plot_radar_comparison(
+    metrics_dict: dict[str, dict[str, float]],
+    title: str = "Model Comparison",
+    save_path: str | None = None,
+    show: bool = True,
+) -> plt.Figure:
+    if not metrics_dict:
+        raise ValueError("metrics_dict must not be empty")
+
+    labels = list(next(iter(metrics_dict.values())).keys())
+    angles = np.linspace(0, 2 * np.pi, len(labels), endpoint=False)
+    angles = np.concatenate([angles, angles[:1]])
+
+    with apply_style() as theme:
+        fig, ax = plt.subplots(
+            figsize=(7, 7),
+            subplot_kw={"projection": "polar"},
+            constrained_layout=True,
+        )
+
+        colors = get_categorical_colors(len(metrics_dict), theme=theme)
+
+        for (model_name, scores), color in zip(metrics_dict.items(), colors):
+            values = [scores[label] for label in labels]
+            values = values + values[:1]
+
+            ax.plot(angles, values, color=color, label=model_name, linewidth=2)
+            ax.fill(angles, values, color=color, alpha=0.2)
+
+        ax.set_xticks(angles[:-1])
+        ax.set_xticklabels(labels)
+        ax.set_title(title, fontweight="bold")
+        ax.grid(True, alpha=theme.grid["alpha"])
+        ax.legend(loc="upper right", bbox_to_anchor=(1.2, 1.1))
+
+        if save_path:
+            fig.savefig(save_path, dpi=theme.fig_defaults["savefig_dpi"], bbox_inches="tight")
+        if show:
+            plt.show()
+
+        plt.close(fig)
+        return fig


### PR DESCRIPTION
## Summary
Add a new plotting function to generate a polished radar chart. Let users compare models across several dimensions.

## Related Issue
Closes #121 

## Type of Change
Please check the type of change:
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 📝 Documentation update (changes to docs or examples)
- [ ] 🧹 Maintenance (refactoring, code cleanup, dependencies)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Changes Made
- Added a new plotting function `trustlens/visualization/comparison_plots.py`.
- Used `Matplotlib's polar axes (subplot_kw={'projection': 'polar'})`.
- Wrapped the logic inside the context manager to ensure styling consistency.
- Added unit tests to check the changes.

## Testing

Command used to execute the new tests:
- `pytest tests/test_comparison_visualization.py`

- [X] All unit tests pass locally.
- [X] Added new tests for the changes made.

## Notes for Reviewers

1.
The original issue gives the signature:
```
plot_radar_comparison(metrics_dict)
```

I wasn't sure if that was the exact signature expected or just a general idea. After checking the other plotting functions, I decided to add three optional parameters `title`, `save_path` and `show` for consistency.

2.
When executing all tests to ensure no regression was introduced (as suggested in the CONTRIBUTING.md), I got this error:

```
tests\backends\test_xgboost_logic.py:3: in <module>
import xgboost as xgb
E   ModuleNotFoundError: No module named 'xgboost'
```

Turns out my venv was missing the module 'xgboost'. I realized the recommended commands in CONTRIBUTING.md, `pip install -e ".[dev]"`, wasn't enough to execute all tests.

This problem was fixed by installing non-dev dependencies `pip install -e ".[dev,full]"`. 

`make install` already uses `[dev,full]` but not CONTRIBUTING.md.

Just mentioning it here this small discrepancy in case it helps newcomers, 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a radar comparison chart for visualizing multiple models’ metrics in one plot.
  * Supports optional saving to a file and interactive display.

* **Bug Fixes**
  * Added validation to prevent generating comparison charts from empty metric data.
  * Added validation to error when models don’t share the same metric dimensions.

* **Tests**
  * Added coverage for empty-input handling, mismatched-dimensions errors, and successful chart creation with sample model metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->