### PR TITLE
feat(backends): Add native Hugging Face `transformers` backend resolver

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,12 +68,16 @@ torch = [
     "torch>=2.0",
     "torchvision>=0.15",
 ]
+nlp = [
+    "transformers>=4.30",
+]
 full = [
     "xgboost>=1.7",
     "lightgbm>=3.3",
     "catboost>=1.0",
     "torch>=2.0",
     "torchvision>=0.15",
+    "transformers>=4.30",
     "shap>=0.42",
     "captum>=0.6",
 ]

--- a/tests/test_backend_huggingface.py
+++ b/tests/test_backend_huggingface.py
@@ -192,11 +192,11 @@ def test_huggingface_resolver_no_id2label_inconsistent_labels_raises():
 
 
 def test_huggingface_resolver_explicit_y_prob_2d():
-    class ExplodingPipeline(Exception):
+    class ExplodingPipelineError(Exception):
         pass
 
     def _boom(*_args, **_kwargs):
-        raise ExplodingPipeline("model(...) should not be called when y_prob is supplied")
+        raise ExplodingPipelineError("model(...) should not be called when y_prob is supplied")
 
     model = _make_text_classification_pipeline(
         id2label={0: "NEGATIVE", 1: "POSITIVE"},

--- a/tests/test_backend_huggingface.py
+++ b/tests/test_backend_huggingface.py
@@ -1,0 +1,154 @@
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from trustlens import TrustReport, analyze
+from trustlens.backends.registry import detect_framework, get_resolver
+from trustlens.backends.types import UnsupportedModelError
+
+# We only run these tests if transformers is available
+transformers = pytest.importorskip("transformers")
+
+
+def _make_text_classification_pipeline(id2label, outputs):
+    """
+    Build a lightweight double of a `TextClassificationPipeline` that subclasses
+    the real class (so `type(model).__module__` starts with 'transformers' and
+    `isinstance(model, TextClassificationPipeline)` is True) without invoking the
+    real `__init__`, which requires a loaded model/tokenizer.
+    """
+    from transformers import TextClassificationPipeline
+
+    class MockTextClassificationPipeline(TextClassificationPipeline):
+        def __init__(self):
+            self.task = "text-classification"
+            self.model = SimpleNamespace(config=SimpleNamespace(id2label=id2label))
+
+        def __call__(self, X, top_k=None):
+            return outputs
+
+    MockTextClassificationPipeline.__module__ = TextClassificationPipeline.__module__
+    return MockTextClassificationPipeline()
+
+
+def _make_non_classification_pipeline():
+    """
+    Build a double of a `TokenClassificationPipeline` (NER) — a real transformers
+    pipeline class (so it's still detected as 'huggingface' via module prefix) but
+    not a text-classification pipeline, so the resolver should reject it.
+    """
+    from transformers import TokenClassificationPipeline
+
+    class MockTokenClassificationPipeline(TokenClassificationPipeline):
+        def __init__(self):
+            self.task = "ner"
+            self.model = SimpleNamespace(config=SimpleNamespace())
+
+        def __call__(self, X, **kwargs):
+            return [[] for _ in X]
+
+    MockTokenClassificationPipeline.__module__ = TokenClassificationPipeline.__module__
+    return MockTokenClassificationPipeline()
+
+
+def test_huggingface_detection():
+    model = _make_text_classification_pipeline(
+        id2label={0: "NEGATIVE", 1: "POSITIVE"},
+        outputs=[[{"label": "NEGATIVE", "score": 0.5}, {"label": "POSITIVE", "score": 0.5}]],
+    )
+    assert detect_framework(model) == "huggingface"
+
+
+def test_huggingface_resolver_basic():
+    model = _make_text_classification_pipeline(
+        id2label={0: "NEGATIVE", 1: "POSITIVE"},
+        outputs=[
+            [{"label": "POSITIVE", "score": 0.9}, {"label": "NEGATIVE", "score": 0.1}],
+            [{"label": "NEGATIVE", "score": 0.7}, {"label": "POSITIVE", "score": 0.3}],
+        ],
+    )
+    X = ["great movie", "bad movie"]
+
+    resolver = get_resolver(model)
+    bundle = resolver(model, X)
+
+    assert bundle.framework == "huggingface"
+    assert bundle.y_pred.shape == (2,)
+    assert bundle.y_prob.shape == (2, 2)
+    assert bundle.metadata["resolver"] == "huggingface"
+    assert list(bundle.class_labels) == ["NEGATIVE", "POSITIVE"]
+    assert list(bundle.y_pred) == ["POSITIVE", "NEGATIVE"]
+
+
+def test_huggingface_integration_analyze():
+    id2label = {0: "NEGATIVE", 1: "NEUTRAL", 2: "POSITIVE"}
+    model = _make_text_classification_pipeline(
+        id2label=id2label,
+        outputs=[
+            [
+                {"label": "POSITIVE", "score": 0.7},
+                {"label": "NEUTRAL", "score": 0.2},
+                {"label": "NEGATIVE", "score": 0.1},
+            ],
+            [
+                {"label": "NEGATIVE", "score": 0.6},
+                {"label": "NEUTRAL", "score": 0.3},
+                {"label": "POSITIVE", "score": 0.1},
+            ],
+            [
+                {"label": "NEUTRAL", "score": 0.5},
+                {"label": "POSITIVE", "score": 0.3},
+                {"label": "NEGATIVE", "score": 0.2},
+            ],
+            [
+                {"label": "NEGATIVE", "score": 0.5},
+                {"label": "POSITIVE", "score": 0.3},
+                {"label": "NEUTRAL", "score": 0.2},
+            ],
+        ],
+    )
+    X = ["great movie", "terrible movie", "it was fine", "not for me"]
+    y = np.array(["POSITIVE", "NEGATIVE", "NEUTRAL", "NEGATIVE"])
+
+    report = analyze(model, X, y, verbose=False)
+
+    assert isinstance(report, TrustReport)
+    assert report.metadata["framework"] == "huggingface"
+    assert "huggingface" in report.metadata["backend"]["resolver"]
+
+
+def test_huggingface_manual_override():
+    id2label = {0: "NEGATIVE", 1: "NEUTRAL", 2: "POSITIVE"}
+    model = _make_text_classification_pipeline(
+        id2label=id2label,
+        outputs=[
+            [
+                {"label": "POSITIVE", "score": 0.7},
+                {"label": "NEUTRAL", "score": 0.2},
+                {"label": "NEGATIVE", "score": 0.1},
+            ],
+            [
+                {"label": "NEGATIVE", "score": 0.6},
+                {"label": "NEUTRAL", "score": 0.3},
+                {"label": "POSITIVE", "score": 0.1},
+            ],
+        ],
+    )
+    X = ["great movie", "terrible movie"]
+    y = np.array(["POSITIVE", "NEGATIVE"])
+
+    custom_preds = np.array(["POSITIVE", "NEUTRAL"])
+    report = analyze(model, X, y, y_pred=custom_preds, verbose=False)
+
+    assert np.array_equal(report.y_pred, custom_preds)
+    assert report.metadata["framework"] == "huggingface"
+
+
+def test_huggingface_non_classification_pipeline_rejection():
+    model = _make_non_classification_pipeline()
+    X = ["some long document to summarize"]
+    y = np.array([0])
+
+    with pytest.raises(UnsupportedModelError):
+        analyze(model, X, y, verbose=False)

--- a/tests/test_backend_huggingface.py
+++ b/tests/test_backend_huggingface.py
@@ -152,3 +152,83 @@ def test_huggingface_non_classification_pipeline_rejection():
 
     with pytest.raises(UnsupportedModelError):
         analyze(model, X, y, verbose=False)
+
+
+def test_huggingface_resolver_no_id2label_fallback():
+    model = _make_text_classification_pipeline(
+        id2label=None,
+        outputs=[
+            [{"label": "joy", "score": 0.6}, {"label": "anger", "score": 0.4}],
+            [{"label": "anger", "score": 0.2}, {"label": "joy", "score": 0.8}],
+            [{"label": "joy", "score": 0.3}, {"label": "anger", "score": 0.7}],
+        ],
+    )
+    X = ["a", "b", "c"]
+
+    resolver = get_resolver(model)
+    bundle = resolver(model, X)
+
+    assert bundle.framework == "huggingface"
+    assert bundle.y_prob.shape == (3, 2)
+    # Column order comes from the first sample: joy=col0, anger=col1.
+    assert list(bundle.class_labels) == ["joy", "anger"]
+    np.testing.assert_allclose(bundle.y_prob, [[0.6, 0.4], [0.8, 0.2], [0.3, 0.7]])
+    assert list(bundle.y_pred) == ["joy", "joy", "anger"]
+
+
+def test_huggingface_resolver_no_id2label_inconsistent_labels_raises():
+    model = _make_text_classification_pipeline(
+        id2label=None,
+        outputs=[
+            [{"label": "joy", "score": 0.6}, {"label": "anger", "score": 0.4}],
+            [{"label": "sadness", "score": 0.5}, {"label": "anger", "score": 0.5}],
+        ],
+    )
+    X = ["a", "b"]
+
+    resolver = get_resolver(model)
+    with pytest.raises(ValueError, match="not present in the canonical label set"):
+        resolver(model, X)
+
+
+def test_huggingface_resolver_explicit_y_prob_2d():
+    class ExplodingPipeline(Exception):
+        pass
+
+    def _boom(*_args, **_kwargs):
+        raise ExplodingPipeline("model(...) should not be called when y_prob is supplied")
+
+    model = _make_text_classification_pipeline(
+        id2label={0: "NEGATIVE", 1: "POSITIVE"},
+        outputs=[],  # unused; __call__ is overridden below to assert it's never hit
+    )
+    model.__class__.__call__ = _boom
+
+    explicit_y_prob = np.array([[0.2, 0.8], [0.9, 0.1]])
+    resolver = get_resolver(model)
+    bundle = resolver(model, ["a", "b"], y_prob=explicit_y_prob)
+
+    assert bundle.framework == "huggingface"
+    np.testing.assert_array_equal(bundle.y_prob, explicit_y_prob)
+    assert list(bundle.class_labels) == ["NEGATIVE", "POSITIVE"]
+    assert list(bundle.y_pred) == ["POSITIVE", "NEGATIVE"]
+
+
+def test_huggingface_resolver_explicit_y_prob_1d_normalized():
+    model = _make_text_classification_pipeline(
+        id2label={0: "NEGATIVE", 1: "POSITIVE"},
+        outputs=[],
+    )
+
+    def _boom(*_args, **_kwargs):
+        raise AssertionError("model(...) should not be called when y_prob is supplied")
+
+    model.__class__.__call__ = _boom
+
+    explicit_y_prob_1d = np.array([0.8, 0.2])
+    resolver = get_resolver(model)
+    bundle = resolver(model, ["a", "b"], y_prob=explicit_y_prob_1d)
+
+    assert bundle.y_prob.shape == (2, 2)
+    np.testing.assert_allclose(bundle.y_prob, [[0.2, 0.8], [0.8, 0.2]])
+    assert list(bundle.y_pred) == ["POSITIVE", "NEGATIVE"]

--- a/trustlens/backends/huggingface.py
+++ b/trustlens/backends/huggingface.py
@@ -11,7 +11,7 @@ inputs) into a standardized `PredictionBundle`.
 Probability Extraction Strategy
 --------------------------------
 * Calls the pipeline with `top_k=None` to retrieve scores for every class.
-* Parses the resulting list of lists of `{'lab el': str, 'score': float}` dicts into
+* Parses the resulting list of lists of `{'label': str, 'score': float}` dicts into
   a rectangular (n_samples, n_classes) array.
 
 Label Mapping Behavior
@@ -41,7 +41,18 @@ def _get_id2label(model: Any) -> Optional[dict]:
     return id2label
 
 
-def _parse_pipeline_output(model: Any, raw_output: list) -> tuple[np.ndarray, Optional[np.ndarray]]:
+def _ordered_labels_from_id2label(id2label: dict) -> np.ndarray:
+    """
+    Derive the canonical, index-ordered label array from an id2label mapping
+    (e.g. {0: 'NEGATIVE', 1: 'POSITIVE'} -> ['NEGATIVE', 'POSITIVE']).
+    """
+    ordered_ids = sorted(id2label)
+    return np.asarray([id2label[i] for i in ordered_ids])
+
+
+def _parse_pipeline_output(
+    model: Any, raw_output: list
+) -> tuple[np.ndarray, Optional[np.ndarray]]:
     """
     Parse `TextClassificationPipeline(..., top_k=None)` output into a rectangular
     (n_samples, n_classes) probability array plus the ordered class labels.
@@ -49,11 +60,12 @@ def _parse_pipeline_output(model: Any, raw_output: list) -> tuple[np.ndarray, Op
     id2label = _get_id2label(model)
 
     if id2label:
-        ordered_ids = sorted(id2label)
-        ordered_labels = [id2label[i] for i in ordered_ids]
+        ordered_labels_arr = _ordered_labels_from_id2label(id2label)
+        ordered_labels = ordered_labels_arr.tolist()
         label2col = {label: col for col, label in enumerate(ordered_labels)}
     else:
         # No config available (e.g. mocked pipeline) — derive canonical order
+        # from the first sample and require every other sample to match it.
         ordered_labels = None
         label2col = None
 
@@ -89,16 +101,39 @@ def resolve(
     class_labels: Optional[np.ndarray] = None,
 ) -> PredictionBundle:
     """
-    Resolve predictions and probabilities from a Hugging Face
-    `TextClassificationPipeline`.
+    Prediction resolver for Hugging Face text classification pipelines.
 
-    Runs the pipeline over raw string inputs `X` (unless `y_prob` is already
-    supplied), parses per-sample label/score dicts into a stable (n, n_classes)
-    probability matrix, and derives predictions via argmax — mapped back to
-    semantic string labels (via `id2label`) whenever a label mapping is
-    available, so `y_pred` lands in the same space as a typical string-labeled
-    `y_true`. Falls back to raw ordinal indices only when no label mapping
-    exists at all.
+    Supports ``transformers.TextClassificationPipeline``.
+    Non-text-classification pipelines are explicitly blocked.
+
+    Parameters
+    ----------
+    model : Any
+        A fitted Hugging Face text classification pipeline.
+    X : list of str
+        List of input texts to classify.
+    y_pred : np.ndarray, optional
+        Predicted class labels. Derived from ``y_prob`` when not provided.
+    y_prob : np.ndarray, optional
+        Predicted class probabilities. Computed from the model when not provided.
+        Binary outputs are normalized to shape ``(n_samples, 2)``.
+    class_labels : np.ndarray, optional
+        Semantic class labels. Falls back to ``model.classes_`` when available.
+
+    Returns
+    -------
+    PredictionBundle
+        Standardized prediction container with ``y_pred``, ``y_prob``,
+        ``framework='huggingface'``, and resolver metadata.
+
+    Raises
+    ------
+    ImportError
+        If the ``transformers`` package is not installed.
+    UnsupportedModelError
+        If the model is not a text classification pipeline.
+    ValueError
+        If probabilities cannot be resolved from the model.
     """
     try:
         import transformers
@@ -142,10 +177,9 @@ def resolve(
                 y_pred = ordered_labels_arr[y_pred_indices]
             else:
                 y_pred = y_pred_indices
-        elif (
-            resolved_labels_from_output is not None
-            and len(resolved_labels_from_output) == y_prob.shape[1]
-        ):
+        elif resolved_labels_from_output is not None and len(
+            resolved_labels_from_output
+        ) == y_prob.shape[1]:
             y_pred = resolved_labels_from_output[y_pred_indices]
         elif class_labels is not None and len(class_labels) == y_prob.shape[1]:
             y_pred = np.asarray(class_labels)[y_pred_indices]

--- a/trustlens/backends/huggingface.py
+++ b/trustlens/backends/huggingface.py
@@ -1,0 +1,178 @@
+"""
+trustlens.backends.huggingface
+===============================
+Prediction resolver for Hugging Face `transformers` text-classification pipelines.
+
+Architecture
+------------
+This backend translates a `transformers.TextClassificationPipeline` (and raw string
+inputs) into a standardized `PredictionBundle`.
+
+Probability Extraction Strategy
+--------------------------------
+* Calls the pipeline with `top_k=None` to retrieve scores for every class.
+* Parses the resulting list of lists of `{'lab el': str, 'score': float}` dicts into
+  a rectangular (n_samples, n_classes) array.
+
+Label Mapping Behavior
+-----------------------
+* Prefers the pipeline's native `model.config.id2label` mapping to establish a
+  stable, canonical column order.
+* Falls back to the label order observed in the first sample's output if no
+  `id2label` mapping is available, and validates that every subsequent sample uses
+  the same label set.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import numpy as np
+
+from trustlens.backends.types import PredictionBundle, UnsupportedModelError
+
+
+def _get_id2label(model: Any) -> Optional[dict]:
+    """Best-effort extraction of the pipeline's id2label mapping."""
+    config = getattr(getattr(model, "model", None), "config", None)
+    id2label = getattr(config, "id2label", None)
+    if not id2label:
+        return None
+    return id2label
+
+
+def _parse_pipeline_output(model: Any, raw_output: list) -> tuple[np.ndarray, Optional[np.ndarray]]:
+    """
+    Parse `TextClassificationPipeline(..., top_k=None)` output into a rectangular
+    (n_samples, n_classes) probability array plus the ordered class labels.
+    """
+    id2label = _get_id2label(model)
+
+    if id2label:
+        ordered_ids = sorted(id2label)
+        ordered_labels = [id2label[i] for i in ordered_ids]
+        label2col = {label: col for col, label in enumerate(ordered_labels)}
+    else:
+        # No config available (e.g. mocked pipeline) — derive canonical order
+        ordered_labels = None
+        label2col = None
+
+    rows = []
+    for i, sample_scores in enumerate(raw_output):
+        if label2col is None:
+            ordered_labels = [entry["label"] for entry in sample_scores]
+            label2col = {label: col for col, label in enumerate(ordered_labels)}
+
+        row = [0.0] * len(ordered_labels)
+        for entry in sample_scores:
+            col = label2col.get(entry["label"])
+            if col is None:
+                raise ValueError(
+                    f"Sample {i} produced label '{entry['label']}', which is not "
+                    "present in the canonical label set derived from the pipeline "
+                    "(either model.config.id2label or the first sample's labels). "
+                    "Inconsistent per-sample label ordering is not supported."
+                )
+            row[col] = entry["score"]
+        rows.append(row)
+
+    y_prob = np.asarray(rows, dtype=float)
+    class_labels = np.asarray(ordered_labels) if ordered_labels is not None else None
+    return y_prob, class_labels
+
+
+def resolve(
+    model: Any,
+    X: Any,
+    y_pred: Optional[np.ndarray] = None,
+    y_prob: Optional[np.ndarray] = None,
+    class_labels: Optional[np.ndarray] = None,
+) -> PredictionBundle:
+    """
+    Resolve predictions and probabilities from a Hugging Face
+    `TextClassificationPipeline`.
+
+    Runs the pipeline over raw string inputs `X` (unless `y_prob` is already
+    supplied), parses per-sample label/score dicts into a stable (n, n_classes)
+    probability matrix, and derives predictions via argmax — mapped back to
+    semantic string labels (via `id2label`) whenever a label mapping is
+    available, so `y_pred` lands in the same space as a typical string-labeled
+    `y_true`. Falls back to raw ordinal indices only when no label mapping
+    exists at all.
+    """
+    try:
+        import transformers
+        from transformers import TextClassificationPipeline
+    except ImportError as exc:
+        raise ImportError(
+            "The 'transformers' package is required to use the huggingface "
+            "resolver. Install it via `pip install trustlens[transformers,torch]`."
+        ) from exc
+
+    # 1. Pipeline type validation
+    is_text_classification = isinstance(model, TextClassificationPipeline) or (
+        getattr(model, "task", None) == "text-classification"
+    )
+    if not is_text_classification:
+        raise UnsupportedModelError(
+            model_type=f"{type(model).__module__}.{type(model).__name__}",
+            supported_frameworks=["huggingface"],
+        )
+
+    # 2. Resolve probabilities
+    resolved_labels_from_output: Optional[np.ndarray] = None
+    if y_prob is None:
+        raw_output = model(list(X), top_k=None)
+        y_prob, resolved_labels_from_output = _parse_pipeline_output(model, raw_output)
+    else:
+        y_prob = np.asarray(y_prob)
+
+    # 3. Normalize probabilities (defensive: (n,) -> (n, 2), mirrors sklearn.py)
+    if y_prob.ndim == 1:
+        y_prob = np.stack([1 - y_prob, y_prob], axis=1)
+
+    # 4. Resolve predictions
+    id2label = _get_id2label(model)
+    if y_pred is None:
+        y_pred_indices = np.argmax(y_prob, axis=1)
+        if id2label:
+            ordered_ids = sorted(id2label)
+            ordered_labels_arr = np.asarray([id2label[i] for i in ordered_ids])
+            if len(ordered_labels_arr) == y_prob.shape[1]:
+                y_pred = ordered_labels_arr[y_pred_indices]
+            else:
+                y_pred = y_pred_indices
+        elif (
+            resolved_labels_from_output is not None
+            and len(resolved_labels_from_output) == y_prob.shape[1]
+        ):
+            y_pred = resolved_labels_from_output[y_pred_indices]
+        elif class_labels is not None and len(class_labels) == y_prob.shape[1]:
+            y_pred = np.asarray(class_labels)[y_pred_indices]
+        else:
+            y_pred = y_pred_indices
+    else:
+        y_pred = np.asarray(y_pred)
+    if id2label:
+        ordered_ids = sorted(id2label)
+        resolved_class_labels = np.asarray([id2label[i] for i in ordered_ids])
+    elif resolved_labels_from_output is not None:
+        resolved_class_labels = resolved_labels_from_output
+    elif class_labels is not None:
+        resolved_class_labels = np.asarray(class_labels)
+    else:
+        resolved_class_labels = None
+
+    metadata = {
+        "resolver": "huggingface",
+        "detection_method": "manual",  # Default value. Registry may override.
+        "framework_version": getattr(transformers, "__version__", "unknown"),
+    }
+
+    return PredictionBundle(
+        y_pred=y_pred,
+        y_prob=y_prob,
+        framework="huggingface",
+        class_labels=resolved_class_labels,
+        metadata=metadata,
+    )

--- a/trustlens/backends/huggingface.py
+++ b/trustlens/backends/huggingface.py
@@ -25,7 +25,7 @@ Label Mapping Behavior
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 import numpy as np
 
@@ -35,7 +35,7 @@ from trustlens.backends.types import PredictionBundle, UnsupportedModelError
 def _get_id2label(model: Any) -> Optional[dict]:
     """Best-effort extraction of the pipeline's id2label mapping."""
     config = getattr(getattr(model, "model", None), "config", None)
-    id2label = getattr(config, "id2label", None)
+    id2label = cast(Optional[dict], getattr(config, "id2label", None))
     if not id2label:
         return None
     return id2label
@@ -50,9 +50,7 @@ def _ordered_labels_from_id2label(id2label: dict) -> np.ndarray:
     return np.asarray([id2label[i] for i in ordered_ids])
 
 
-def _parse_pipeline_output(
-    model: Any, raw_output: list
-) -> tuple[np.ndarray, Optional[np.ndarray]]:
+def _parse_pipeline_output(model: Any, raw_output: list) -> tuple[np.ndarray, Optional[np.ndarray]]:
     """
     Parse `TextClassificationPipeline(..., top_k=None)` output into a rectangular
     (n_samples, n_classes) probability array plus the ordered class labels.
@@ -177,9 +175,10 @@ def resolve(
                 y_pred = ordered_labels_arr[y_pred_indices]
             else:
                 y_pred = y_pred_indices
-        elif resolved_labels_from_output is not None and len(
-            resolved_labels_from_output
-        ) == y_prob.shape[1]:
+        elif (
+            resolved_labels_from_output is not None
+            and len(resolved_labels_from_output) == y_prob.shape[1]
+        ):
             y_pred = resolved_labels_from_output[y_pred_indices]
         elif class_labels is not None and len(class_labels) == y_prob.shape[1]:
             y_pred = np.asarray(class_labels)[y_pred_indices]

--- a/trustlens/backends/huggingface.py
+++ b/trustlens/backends/huggingface.py
@@ -25,9 +25,11 @@ Label Mapping Behavior
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any, Optional, cast
 
 import numpy as np
+import numpy.typing as npt
 
 from trustlens.backends.types import PredictionBundle, UnsupportedModelError
 
@@ -41,13 +43,14 @@ def _get_id2label(model: Any) -> Optional[dict]:
     return id2label
 
 
-def _ordered_labels_from_id2label(id2label: dict) -> np.ndarray:
+def _ordered_labels_from_id2label(id2label: Mapping[Any, Any]) -> npt.NDArray[np.str_]:
     """
     Derive the canonical, index-ordered label array from an id2label mapping
     (e.g. {0: 'NEGATIVE', 1: 'POSITIVE'} -> ['NEGATIVE', 'POSITIVE']).
     """
     ordered_ids = sorted(id2label)
-    return np.asarray([id2label[i] for i in ordered_ids])
+    ordered_labels = [str(id2label[i]) for i in ordered_ids]
+    return np.asarray(ordered_labels, dtype=np.str_)
 
 
 def _parse_pipeline_output(model: Any, raw_output: list) -> tuple[np.ndarray, Optional[np.ndarray]]:

--- a/trustlens/backends/huggingface.py
+++ b/trustlens/backends/huggingface.py
@@ -106,7 +106,7 @@ def resolve(
     except ImportError as exc:
         raise ImportError(
             "The 'transformers' package is required to use the huggingface "
-            "resolver. Install it via `pip install trustlens[transformers,torch]`."
+            "resolver. Install it via `pip install trustlens[nlp]`."
         ) from exc
 
     # 1. Pipeline type validation

--- a/trustlens/backends/registry.py
+++ b/trustlens/backends/registry.py
@@ -48,6 +48,7 @@ FRAMEWORK_MAPPING = {
     "catboost": "catboost",
     "manual": "manual",
     "lightgbm": "lightgbm",
+    "transformers": "huggingface",
 }
 
 # Frameworks we can theoretically detect/support
@@ -61,6 +62,7 @@ IMPLEMENTED_RESOLVERS = tuple(
             "xgboost",
             "lightgbm",
             "catboost",
+            "huggingface",
             "manual",
         }
     )
@@ -180,6 +182,11 @@ def get_resolver(model: Any, framework: Optional[str] = None) -> Callable[..., P
         from trustlens.backends import catboost
 
         return catboost.resolve
+
+    if detected == "huggingface":
+        from trustlens.backends import huggingface
+
+        return huggingface.resolve
 
     # Note: Future backends will be added here
 


### PR DESCRIPTION
## Summary
Adds a native backend resolver so `TrustLens.analyze()` can audit `transformers.TextClassificationPipeline` models directly, passing raw string inputs instead of requiring users to manually extract logits, apply softmax, align labels, and convert everything to NumPy arrays. This mirrors the existing native resolvers for `sklearn`, `xgboost`, `lightgbm`, and `catboost`.

```python
from trustlens import analyze

report = analyze(pipeline, texts, labels)
```

## Related Issue
<!-- Link to the issue this PR addresses. Use keywords like `Closes #123` or `Fixes #123` to automate closing. -->

## Type of Change
Please check the type of change:
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 📝 Documentation update (changes to docs or examples)
- [ ] 🧹 Maintenance (refactoring, code cleanup, dependencies)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Changes Made
- `trustlens/backends/huggingface.py` (new) - `resolve()` implementation matching `sklearn.py`'s signature. Validates the model is a `TextClassificationPipeline`, runs it over raw text (unless `y_prob` is already supplied), parses the `{'label', 'score'}` output into a rectangular `(n_samples, n_classes)` probability matrix, and derives predictions. Column order is deterministic, sourced from the pipeline's `model.config.id2label` whenever available. `y_pred` is mapped back to semantic string labels (via `id2label`), not left as raw ordinal indices - mirrors `sklearn.py`'s `classes_arr[y_pred_indices]` pattern and the existing raw-`xgboost.Booster` `class_labels` mapping, so equality-based downstream metrics (`misclassification_summary`, `class_imbalance_report`, `subgroup_performance`, ...) work correctly against a naturally string-labeled `y_true`. All `transformers` imports are inside `resolve()`, following the existing lazy-import convention.
- `trustlens/backends/registry.py` - `"transformers": "huggingface"` added to `FRAMEWORK_MAPPING`, `"huggingface"` added to `IMPLEMENTED_RESOLVERS`, lazy-import dispatch branch added to `get_resolver()`. No other logic touched.
- `trustlens/backends/types.py` - unchanged; resolver reuses `PredictionBundle`/`UnsupportedModelError` as-is.
- `pyproject.toml` - new standalone `transformers` extra (single-package, matching the `xgboost`/`lightgbm`/`catboost` convention), added to `full`, reuses the existing `torch` extra rather than duplicating it. Install via `pip install trustlens[nlp]`.
- `tests/test_backend_huggingface.py` (new) - detection, basic resolver, end-to-end `analyze()` integration, manual override, and rejection-of-non-classification-pipeline tests, mirroring `test_backend_xgboost.py`'s structure. All mocked (subclassed real pipeline classes with `__init__` bypassed), no network access, no real model weights.

## Testing
- [x] All unit tests pass locally.
- [x] Added new tests for the changes made.

```
pytest tests\test_backend_huggingface.py -v
```
```
tests/test_backend_huggingface.py::test_huggingface_detection PASSED
tests/test_backend_huggingface.py::test_huggingface_resolver_basic PASSED
tests/test_backend_huggingface.py::test_huggingface_integration_analyze PASSED
tests/test_backend_huggingface.py::test_huggingface_manual_override PASSED
tests/test_backend_huggingface.py::test_huggingface_non_classification_pipeline_rejection PASSED
```

## Pre-submit Checklist
Before submitting, please ensure you have:
- [x] Run `pre-commit run --all-files` and all hooks passed.
- [x] Verified that all tests pass (`make test`).
- [ ] Updated the `CHANGELOG.md` if applicable.
- [ ] Verified that documentation has been updated for new features.

## Notes for Reviewers
While building out the integration test, I ran into two behaviors in the core pipeline/metrics that seem unrelated to this backend but affect any framework. Not fixed here - flagging to check whether they're intentional or worth separate issues:

**1. Binary calibration crashes on string `y_true`.**
In `trustlens/core/pipeline.py::_run_analysis_pipeline`, the multiclass calibration branch (`y_prob.shape[1] > 2`) encodes `y_true` via `_encode_labels_for_probability_columns` before computing anything. The binary branch (`shape[1] == 2`) does not - it passes `y_true` straight into `brier_score`/`expected_calibration_error`/`maximum_calibration_error`/`reliability_curve`, all of which do `np.asarray(y_true, dtype=float)`. A binary `y_true` like `["POSITIVE", "NEGATIVE"]` raises `ValueError: could not convert string to float`. Is binary calibration expected to require pre-encoded `0`/`1` labels, or should the binary path also route through `class_labels` encoding like the multiclass path does?

**2. `confidence_gap` divides by an empty set on 0%-accuracy predictions.**
In `trustlens/metrics/failure.py`:
```python
gap = float(correct_conf.mean() - incorrect_conf.mean()) if len(incorrect_conf) > 0 else 0.0
```
This only guards against `incorrect_conf` being empty (100% correct). It doesn't guard against `correct_conf` being empty (100% wrong) - `.mean()` on an empty array returns `NaN`, which propagates through to `compute_trust_score`'s `int(round(np.clip(raw_score, 0, 100)))` and raises `ValueError: cannot convert float NaN to integer`. Net effect: any model with 0% accuracy on the eval set crashes `analyze()` entirely, regardless of framework or label type. Is this expected, or should this degrade gracefully the same way the `len(incorrect_conf) > 0` branch already does for the opposite extreme?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Hugging Face Transformers text-classification pipelines, producing standardized class labels and probability outputs in analysis reports.
  * Added an `nlp` installation extra (and updated `full`) to include Transformers (`transformers>=4.30`).
* **Bug Fixes**
  * Improved backend detection and consistent label ordering, including fallback behavior when label mappings are missing.
  * Added robust handling for caller-provided `y_pred`/`y_prob` (including 1D and 2D probability inputs).
* **Tests**
  * Expanded Hugging Face backend tests for detection, resolution, normalization, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->