### PR TITLE
fix(core): handle binary semantic labels and confidence gap edge cases

### DIFF
--- a/tests/test_core_pipeline.py
+++ b/tests/test_core_pipeline.py
@@ -12,3 +12,44 @@ def test_encode_labels_rejects_class_label_length_mismatch():
         ValueError, match=r"class_labels length \(2\).*probability column shape \(3 columns\)"
     ):
         _encode_labels_for_probability_columns(y_true, 3, class_labels)
+
+
+def test_binary_calibration_with_semantic_labels():
+    from trustlens.core.pipeline import _run_analysis_pipeline
+
+    y_true_int = np.array([0, 1, 0, 1])
+    y_true_str = np.array(["NEGATIVE", "POSITIVE", "NEGATIVE", "POSITIVE"])
+    class_labels = np.array(["NEGATIVE", "POSITIVE"])
+    y_prob = np.array([[0.8, 0.2], [0.1, 0.9], [0.6, 0.4], [0.3, 0.7]])
+
+    # Run with integer labels
+    report_int = _run_analysis_pipeline(
+        model=None,
+        X=np.zeros((4, 2)),
+        y_true=y_true_int,
+        y_pred=y_true_int,
+        y_prob=y_prob,
+        modules=["calibration"],
+        class_labels=np.array([0, 1]),
+        verbose=False,
+    )
+
+    # Run with string labels
+    report_str = _run_analysis_pipeline(
+        model=None,
+        X=np.zeros((4, 2)),
+        y_true=y_true_str,
+        y_pred=y_true_str,
+        y_prob=y_prob,
+        modules=["calibration"],
+        class_labels=class_labels,
+        verbose=False,
+    )
+
+    # Verify metrics are identical
+    metrics_int = report_int.results["calibration"]
+    metrics_str = report_str.results["calibration"]
+
+    assert metrics_int["ece"] == metrics_str["ece"]
+    assert metrics_int["brier_score"] == metrics_str["brier_score"]
+    assert metrics_int["mce"] == metrics_str["mce"]

--- a/tests/test_failure.py
+++ b/tests/test_failure.py
@@ -95,3 +95,21 @@ class TestConfidenceGap:
         y_true, y_pred, y_prob = binary_data
         result = confidence_gap(y_true, y_pred, y_prob)
         assert result["n_correct"] + result["n_incorrect"] == len(y_true)
+
+    def test_gap_zero_when_all_correct(self, binary_data):
+        y_true, _, y_prob = binary_data
+        y_pred = y_true.copy()  # 100% accuracy
+        result = confidence_gap(y_true, y_pred, y_prob)
+        assert result["gap"] == 0.0
+        assert not np.isnan(result["gap"])
+        assert result["n_incorrect"] == 0
+        assert result["n_correct"] == len(y_true)
+
+    def test_gap_zero_when_all_incorrect(self, binary_data):
+        y_true, _, y_prob = binary_data
+        y_pred = 1 - y_true  # 0% accuracy
+        result = confidence_gap(y_true, y_pred, y_prob)
+        assert result["gap"] == 0.0
+        assert not np.isnan(result["gap"])
+        assert result["n_correct"] == 0
+        assert result["n_incorrect"] == len(y_true)

--- a/trustlens/core/pipeline.py
+++ b/trustlens/core/pipeline.py
@@ -181,11 +181,15 @@ def _run_analysis_pipeline(
                 else:
                     y_prob_pos = y_prob
 
+                y_true_encoded = _encode_labels_for_probability_columns(
+                    y_true, 2, class_labels
+                )
+
                 results["calibration"] = {
-                    "brier_score": brier_score(y_true, y_prob_pos),
-                    "ece": expected_calibration_error(y_true, y_prob_pos),
-                    "mce": maximum_calibration_error(y_true, y_prob_pos),
-                    "reliability_curve": reliability_curve(y_true, y_prob_pos),
+                    "brier_score": brier_score(y_true_encoded, y_prob_pos),
+                    "ece": expected_calibration_error(y_true_encoded, y_prob_pos),
+                    "mce": maximum_calibration_error(y_true_encoded, y_prob_pos),
+                    "reliability_curve": reliability_curve(y_true_encoded, y_prob_pos),
                 }
         else:
             logger.warning("Skipped calibration: y_prob is missing.")

--- a/trustlens/core/pipeline.py
+++ b/trustlens/core/pipeline.py
@@ -181,9 +181,7 @@ def _run_analysis_pipeline(
                 else:
                     y_prob_pos = y_prob
 
-                y_true_encoded = _encode_labels_for_probability_columns(
-                    y_true, 2, class_labels
-                )
+                y_true_encoded = _encode_labels_for_probability_columns(y_true, 2, class_labels)
 
                 results["calibration"] = {
                     "brier_score": brier_score(y_true_encoded, y_prob_pos),

--- a/trustlens/metrics/failure.py
+++ b/trustlens/metrics/failure.py
@@ -138,7 +138,8 @@ def confidence_gap(
     Interpretation guidance
     -----------------------
     Higher gap is better. A large positive gap indicates the model lowers its confidence
-    when making mistakes.
+    when making mistakes. If the model is 100% correct or 0% correct (one of the comparison
+    groups is empty), the gap is defined as 0.0.
 
     Returns
     -------
@@ -172,13 +173,17 @@ def confidence_gap(
     correct_hist, _ = np.histogram(correct_conf, bins=bins)
     incorrect_hist, _ = np.histogram(incorrect_conf, bins=bins)
 
-    gap = float(correct_conf.mean() - incorrect_conf.mean()) if len(incorrect_conf) > 0 else 0.0
+    correct_mean = float(correct_conf.mean()) if len(correct_conf) > 0 else 0.0
+    incorrect_mean = float(incorrect_conf.mean()) if len(incorrect_conf) > 0 else 0.0
+
+    if len(correct_conf) == 0 or len(incorrect_conf) == 0:
+        gap = 0.0
+    else:
+        gap = correct_mean - incorrect_mean
 
     return {
-        "correct_confidence_mean": float(correct_conf.mean()) if len(correct_conf) > 0 else 0.0,
-        "incorrect_confidence_mean": float(incorrect_conf.mean())
-        if len(incorrect_conf) > 0
-        else 0.0,
+        "correct_confidence_mean": correct_mean,
+        "incorrect_confidence_mean": incorrect_mean,
         "gap": round(gap, 4),
         "histogram_bins": bins,
         "correct_hist": correct_hist,


### PR DESCRIPTION
## Summary

This PR fixes two unrelated but pre-existing robustness issues in the TrustLens core that were identified while implementing the Hugging Face backend in #168.

### 1. Binary calibration now supports semantic labels

The binary calibration path in `trustlens/core/pipeline.py` previously bypassed label encoding and passed `y_true` directly into the calibration metrics. As a result, binary classification with semantic labels (e.g. `"POSITIVE"` / `"NEGATIVE"`) raised a `ValueError` when downstream metrics attempted to convert labels to floats.

This PR aligns the binary path with the existing multiclass implementation by encoding `y_true` through `_encode_labels_for_probability_columns(...)` before computing:

- Brier Score
- Expected Calibration Error (ECE)
- Maximum Calibration Error (MCE)
- Reliability Curve

This makes binary and multiclass calibration behavior consistent across all supported backends.

### 2. Handle 0% accuracy in `confidence_gap`

`confidence_gap` previously guarded against an empty `incorrect_conf` array (100% accuracy) but not an empty `correct_conf` array (0% accuracy). In the latter case, `correct_conf.mean()` returned `NaN`, which propagated into Trust Score computation and caused `analyze()` to fail.

The implementation now handles both edge cases symmetrically. When either comparison group is empty, the confidence gap is defined as `0.0`, preventing `NaN` propagation while keeping normal behavior unchanged for typical evaluation scenarios.

The metric documentation has also been updated to explicitly document this behavior.

## Validation

### Binary calibration

- ✅ Integer labels continue to work
- ✅ Semantic string labels now work correctly
- ✅ Label encoding preserves `class_labels` ordering
- ✅ ECE, MCE, Brier Score, and Reliability Curve produce identical results for semantic labels and their encoded equivalents

### Confidence gap

- ✅ 100% accuracy handled correctly
- ✅ 0% accuracy handled correctly (no NaN propagation)
- ✅ Mixed accuracy behavior unchanged
- ✅ Trust Score no longer crashes on 0% accuracy
- ✅ Documentation updated to reflect edge-case behavior

These changes are backward compatible and improve the robustness of the core evaluation pipeline without changing the behavior for existing valid inputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calibration metrics for binary classification when probability columns follow a nonstandard class order, including support for semantic (string) class labels.
  * Defined `confidence_gap` behavior when all predictions are correct or all are incorrect, returning a consistent `gap` of `0.0` (no `NaN`).
* **Tests**
  * Added coverage to confirm binary calibration metrics are identical for integer vs semantic labels and to validate `confidence_gap` edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->